### PR TITLE
Retry on 429s (too many requests) from Matrix server

### DIFF
--- a/client.go
+++ b/client.go
@@ -517,6 +517,27 @@ func (cli *Client) handleResponseError(req *http.Request, res *http.Response) ([
 	}
 }
 
+// parseBackoffFromResponse extracts the backoff time specified in the Retry-After header if present. See
+// https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Retry-After.
+func (cli *Client) parseBackoffFromResponse(res *http.Response, now time.Time, fallback time.Duration) time.Duration {
+	retryAfterHeaderValue := res.Header.Get("Retry-After")
+	if retryAfterHeaderValue == "" {
+		return fallback
+	}
+
+	if t, err := time.Parse(http.TimeFormat, retryAfterHeaderValue); err == nil {
+		return t.Sub(now)
+	}
+
+	if seconds, err := strconv.Atoi(retryAfterHeaderValue); err == nil {
+		return time.Duration(seconds) * time.Second
+	}
+
+	cli.logWarning(`Failed to parse Retry-After header value "%s"`, retryAfterHeaderValue)
+
+	return fallback
+}
+
 func (cli *Client) executeCompiledRequest(req *http.Request, retries int, backoff time.Duration, responseJSON interface{}, handler ClientResponseHandler) ([]byte, error) {
 	cli.LogRequest(req)
 	res, err := cli.Client.Do(req)
@@ -536,7 +557,10 @@ func (cli *Client) executeCompiledRequest(req *http.Request, retries int, backof
 		}
 	}
 
-	if retries > 0 && (res.StatusCode == http.StatusBadGateway || res.StatusCode == http.StatusServiceUnavailable || res.StatusCode == http.StatusGatewayTimeout) {
+	if retries > 0 && (res.StatusCode == http.StatusBadGateway || res.StatusCode == http.StatusServiceUnavailable || res.StatusCode == http.StatusGatewayTimeout || res.StatusCode == http.StatusTooManyRequests) {
+		if res.StatusCode == http.StatusTooManyRequests {
+			backoff = cli.parseBackoffFromResponse(res, time.Now(), backoff)
+		}
 		return cli.doRetry(req, fmt.Errorf("HTTP %d", res.StatusCode), retries, backoff, responseJSON, handler)
 	}
 

--- a/client_internal_test.go
+++ b/client_internal_test.go
@@ -1,0 +1,75 @@
+package mautrix
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+)
+
+type testLogger struct {
+	StubLogger
+
+	lastLogged string
+}
+
+func (tl *testLogger) Warnfln(message string, args ...interface{}) {
+	tl.lastLogged = fmt.Sprintf(message, args...)
+}
+
+func TestBackoffFromResponse(t *testing.T) {
+	now := time.Now().Truncate(time.Second)
+
+	defaultBackoff := time.Duration(123)
+
+	for name, tt := range map[string]struct {
+		headerValue string
+		expected    time.Duration
+		expectedLog string
+	}{
+		"AsDate": {
+			headerValue: now.In(time.UTC).Add(5 * time.Hour).Format(http.TimeFormat),
+			expected:    time.Duration(5) * time.Hour,
+			expectedLog: "",
+		},
+		"AsSeconds": {
+			headerValue: "12345",
+			expected:    time.Duration(12345) * time.Second,
+			expectedLog: "",
+		},
+		"Missing": {
+			headerValue: "",
+			expected:    defaultBackoff,
+			expectedLog: "",
+		},
+		"Bad": {
+			headerValue: "invalid",
+			expected:    defaultBackoff,
+			expectedLog: `Failed to parse Retry-After header value "invalid"`,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			logger := &testLogger{}
+
+			c := &Client{Logger: logger}
+
+			actual := c.parseBackoffFromResponse(
+				&http.Response{
+					Header: http.Header{
+						"Retry-After": []string{tt.headerValue},
+					},
+				},
+				now,
+				time.Duration(123),
+			)
+
+			if actual != tt.expected {
+				t.Fatalf("Backoff duration output mismatch, expected %s, got %s", tt.expected, actual)
+			}
+
+			if logger.lastLogged != tt.expectedLog {
+				t.Fatalf(`Log line mismatch, expected "%s", got "%s"`, tt.expectedLog, logger.lastLogged)
+			}
+		})
+	}
+}


### PR DESCRIPTION
I noticed that when backfilling messages after my `mautrix-imessage` has been offline for a while, many of the messages get lost due to 429s from my Matrix server.

This PR attempts to resolve that by adding 429 to the list of status codes that are retried by the client. The optional `Retry-After` header that may come back with it is parsed and overrides the default backoff time if present to ideally prevent subsequent 429s. If no `Retry-After` header is present, then the default `backoff` is used.

Question: if a 429 is returned, should the remaining retry count still be reduced? I'd argue no and just keep retrying until the 429 goes away as that insinuates that any future requests made are more likely to also fail anyway.