### PR TITLE
fix GetAvatarURL to correctly retrieve the right avatar

### DIFF
--- a/client.go
+++ b/client.go
@@ -807,7 +807,7 @@ func (cli *Client) SetDisplayName(displayName string) (err error) {
 
 // GetAvatarURL gets the avatar URL of the user with the specified MXID. See https://spec.matrix.org/v1.2/client-server-api/#get_matrixclientv3profileuseridavatar_url
 func (cli *Client) GetAvatarURL(mxid id.UserID) (url id.ContentURI, err error) {
-	urlPath := cli.BuildClientURL("v3", "profile", cli.UserID, "avatar_url")
+	urlPath := cli.BuildClientURL("v3", "profile", mxid, "avatar_url")
 	s := struct {
 		AvatarURL id.ContentURI `json:"avatar_url"`
 	}{}


### PR DESCRIPTION
Hello,

while trying to work on migrating [matterbridge](https://github.com/42wim/matterbridge) to this library, I ran into this tiny issue: `GetAvatarURL` always retrieves the avatar URL of the client itself.

This fixed it for me.