### PR TITLE
MSC3870: allow media create endpoint to specify alternate upload URL

### DIFF
--- a/responses.go
+++ b/responses.go
@@ -107,6 +107,7 @@ type RespMediaUpload struct {
 type RespCreateMXC struct {
 	ContentURI      id.ContentURI `json:"content_uri"`
 	UnusedExpiresAt int           `json:"unused_expires_at,omitempty"`
+	UploadURL       string        `json:"upload_url,omitempty"`
 }
 
 // RespPreviewURL is the JSON response for https://spec.matrix.org/v1.2/client-server-api/#get_matrixmediav3preview_url


### PR DESCRIPTION
[MSC3870](https://github.com/Fizzadar/matrix-spec-proposals/blob/media-async-upload-url/proposals/3870-media-async-upload-url.md) extends the async media uploads spec to allow the server to specify a URL to send the media to.

There is another related change to indicate to the server that we will follow redirects when downloading media