### PR TITLE
Ignore invite error message from dendrite when user is already in the room

### DIFF
--- a/appservice/intent.go
+++ b/appservice/intent.go
@@ -544,7 +544,9 @@ func (intent *IntentAPI) EnsureInvited(roomID id.RoomID, userID id.UserID) error
 		_, err := intent.InviteUser(roomID, &mautrix.ReqInviteUser{
 			UserID: userID,
 		})
-		if httpErr, ok := err.(mautrix.HTTPError); ok && httpErr.RespError != nil && strings.Contains(httpErr.RespError.Err, "is already in the room") {
+		if httpErr, ok := err.(mautrix.HTTPError); ok &&
+			httpErr.RespError != nil &&
+			(strings.Contains(httpErr.RespError.Err, "is already in the room") || strings.Contains(httpErr.RespError.Err, "is already joined to room")) {
 			return nil
 		}
 		return err


### PR DESCRIPTION
In Dendrite, the error message when a user is invited in a room they've already joined is different from the one returned by Synapse.

See https://github.com/matrix-org/dendrite/blob/main/roomserver/internal/perform/perform_invite.go#L178