### PR TITLE
matrix server unix socket connection support

### DIFF
--- a/bridge/bridge.go
+++ b/bridge/bridge.go
@@ -548,13 +548,12 @@ func (br *Bridge) start() {
 		br.LogDBUpgradeErrorAndExit("matrix_state", err)
 	}
 
-	if br.AS.Host.Port != 0 {
+	if br.AS.Host.IsConfigured() {
 		br.ZLog.Debug().Msg("Starting application service HTTP server")
 		go br.AS.Start()
 	} else {
-		br.ZLog.Debug().Msg("Appservice port not configured, not starting HTTP server")
+		br.ZLog.Debug().Msg("Appservice port or unix socket is not configured, not starting HTTP server")
 	}
-
 	br.ZLog.Debug().Msg("Checking connection to homeserver")
 	br.ensureConnection()
 	go br.fetchMediaConfig()

--- a/bridge/bridgeconfig/config.go
+++ b/bridge/bridgeconfig/config.go
@@ -103,6 +103,7 @@ func (config *BaseConfig) MakeAppService() *appservice.AppService {
 	as := appservice.Create()
 	as.HomeserverDomain = config.Homeserver.Domain
 	as.HomeserverURL = config.Homeserver.Address
+	as.HTTPClient = appservice.CreateHTTPClient(as.HomeserverURL)
 	as.Host.Hostname = config.AppService.Hostname
 	as.Host.Port = config.AppService.Port
 	as.DefaultHTTPRetries = 4

--- a/url.go
+++ b/url.go
@@ -18,7 +18,11 @@ func parseAndNormalizeBaseURL(homeserverURL string) (*url.URL, error) {
 	if err != nil {
 		return nil, err
 	}
-	if hsURL.Scheme == "" {
+	if strings.HasPrefix(homeserverURL, "/") {
+		hsURL.Scheme = "http"
+		hsURL.Host = "unix"
+		hsURL.Path = ""
+	} else if hsURL.Scheme == "" {
 		hsURL.Scheme = "https"
 		fixedURL := hsURL.String()
 		hsURL, err = url.Parse(fixedURL)

--- a/url_test.go
+++ b/url_test.go
@@ -63,3 +63,13 @@ func TestClient_BuildURL_MissingSchemeWithPath(t *testing.T) {
 	built := cli.BuildClientURL("v3", "foo/bar%2F🐈 1", "hello", "world")
 	assert.Equal(t, "https://example.com/base/_matrix/client/v3/foo%2Fbar%252F%F0%9F%90%88%201/hello/world", built)
 }
+
+func TestClient_BuildURL_UnixSocket(t *testing.T) {
+	cli, err := mautrix.NewClient("/path", "", "")
+	assert.NoError(t, err)
+	assert.Equal(t, cli.HomeserverURL.Scheme, "http")
+	assert.Equal(t, cli.HomeserverURL.Host, "unix")
+	assert.Equal(t, cli.HomeserverURL.Path, "")
+	built := cli.BuildClientURL("v3", "foo/bar%2F🐈 1", "hello", "world")
+	assert.Equal(t, "http://unix/_matrix/client/v3/foo%2Fbar%252F%F0%9F%90%88%201/hello/world", built)
+}


### PR DESCRIPTION
Matrix server now supports listening on a unix socket: https://github.com/matrix-org/dendrite/commit/6b1c9eafa97cb02dd902ddbf2676c709c86f9625
I would like to be able to use that feature as I am running multiple services on a small RPi like device and it removes port management. I have tested this on my device.

PR includes both client side (home server) and server side (app service) support.
I am not sure but it looks like appservice.address is not used.
Config looks like this:
```
homeserver:
  address: /var/snap/matrix/current/matrix.socket
...
appservice:
  address: /var/snap/matrix/current/whatsapp.socket
  hostname: /var/snap/matrix/current/whatsapp.socket
  port: 0

```
