### PR TITLE
fix warning that is logged when attempting to unmarshal empty value in encryption column for public rooms

### DIFF
--- a/sqlstatestore/statestore.go
+++ b/sqlstatestore/statestore.go
@@ -215,6 +215,9 @@ func (store *SQLStateStore) GetEncryptionEvent(roomID id.RoomID) *event.Encrypti
 		}
 		return nil
 	}
+	if !json.Valid(data) {
+		return nil
+	}
 	content := &event.EncryptionEventContent{}
 	err = json.Unmarshal(data, content)
 	if err != nil {


### PR DESCRIPTION
Running [example](https://github.com/mautrix/go/blob/master/example/main.go) code, I am seeing a lot of these warnings:

```
3:01PM WRN Failed to parse encryption config of !GtIfdsfQtQIgbQSxwJ:archlinux.org: unexpected end of JSON input component=crypto db_section=matrix_state` for public rooms
```

For public rooms, encryption column is empty and attempting to unmarshal logs a warning. This PR checks whether a json value is valid json before attempting to unmarshall it and returns `nil` if so.

