### PR TITLE
Allow cryptohelper to be used with an in-memory store

### DIFF
--- a/crypto/cryptohelper/cryptohelper.go
+++ b/crypto/cryptohelper/cryptohelper.go
@@ -361,8 +361,7 @@ func (helper *CryptoHelper) Encrypt(roomID id.RoomID, evtType event.Type, conten
 			Str("room_id", roomID.String()).
 			Msg("Got session error while encrypting event, sharing group session and trying again")
 		var users []id.UserID
-		// TODO don't use managedStateStore
-		users, err = helper.managedStateStore.GetRoomJoinedOrInvitedMembers(roomID)
+		users, err = helper.client.StateStore.GetRoomJoinedOrInvitedMembers(roomID)
 		if err != nil {
 			err = fmt.Errorf("failed to get room member list: %w", err)
 		} else if err = helper.mach.ShareGroupSession(ctx, roomID, users); err != nil {

--- a/statestore.go
+++ b/statestore.go
@@ -28,6 +28,8 @@ type StateStore interface {
 
 	SetEncryptionEvent(roomID id.RoomID, content *event.EncryptionEventContent)
 	IsEncrypted(roomID id.RoomID) bool
+
+	GetRoomJoinedOrInvitedMembers(roomID id.RoomID) ([]id.UserID, error)
 }
 
 func UpdateStateStore(store StateStore, evt *event.Event) {
@@ -101,6 +103,15 @@ func (store *MemoryStateStore) GetRoomMembers(roomID id.RoomID) map[id.UserID]*e
 		store.membersLock.Unlock()
 	}
 	return members
+}
+
+func (store *MemoryStateStore) GetRoomJoinedOrInvitedMembers(roomID id.RoomID) ([]id.UserID, error) {
+	members := store.GetRoomMembers(roomID)
+	ids := make([]id.UserID, 0, len(members))
+	for id := range members {
+		ids = append(ids, id)
+	}
+	return ids, nil
 }
 
 func (store *MemoryStateStore) GetMembership(roomID id.RoomID, userID id.UserID) event.Membership {


### PR DESCRIPTION
This fixes a TODO comment found in the latest release.

The change seems pretty straight forward to me, but i'm not sure if `helper.client.StateStore` can always be used. Would love a double-check on that.