### PR TITLE
Initialize map in constructor

### DIFF
--- a/statestore.go
+++ b/statestore.go
@@ -74,6 +74,7 @@ func NewMemoryStateStore() StateStore {
 		Registrations: make(map[id.UserID]bool),
 		Members:       make(map[id.RoomID]map[id.UserID]*event.MemberEventContent),
 		PowerLevels:   make(map[id.RoomID]*event.PowerLevelsEventContent),
+		Encryption:    make(map[id.RoomID]*event.EncryptionEventContent),
 	}
 }
 


### PR DESCRIPTION
Running the constructor for the MemoryStateStore and then using it with an encrypted channel leads to a `panic: assignment to entry in nil map`

This PR fixes that.