### PR TITLE
Allow disabling automatic key fetching for Olm machine

### DIFF
--- a/crypto/encryptmegolm.go
+++ b/crypto/encryptmegolm.go
@@ -229,12 +229,16 @@ func (mach *OlmMachine) ShareGroupSession(ctx context.Context, roomID id.RoomID,
 
 	if len(fetchKeys) > 0 {
 		log.Debug().Strs("users", strishArray(fetchKeys)).Msg("Fetching missing keys")
-		for userID, devices := range mach.fetchKeys(ctx, fetchKeys, "", true) {
-			log.Debug().
-				Int("device_count", len(devices)).
-				Str("target_user_id", userID.String()).
-				Msg("Got device keys for user")
-			missingSessions[userID] = devices
+		if keys, err := mach.FetchKeys(ctx, fetchKeys, true); err != nil {
+			log.Err(err).Strs("users", strishArray(fetchKeys)).Msg("Failed to fetch missing keys")
+		} else if keys != nil {
+			for userID, devices := range keys {
+				log.Debug().
+					Int("device_count", len(devices)).
+					Str("target_user_id", userID.String()).
+					Msg("Got device keys for user")
+				missingSessions[userID] = devices
+			}
 		}
 	}
 

--- a/crypto/sql_store_upgrade/00-latest-revision.sql
+++ b/crypto/sql_store_upgrade/00-latest-revision.sql
@@ -1,4 +1,4 @@
--- v0 -> v10: Latest revision
+-- v0 -> v11: Latest revision
 CREATE TABLE IF NOT EXISTS crypto_account (
 	account_id TEXT    PRIMARY KEY,
 	device_id  TEXT    NOT NULL,
@@ -17,7 +17,8 @@ CREATE TABLE IF NOT EXISTS crypto_message_index (
 );
 
 CREATE TABLE IF NOT EXISTS crypto_tracked_user (
-	user_id TEXT PRIMARY KEY
+	user_id          TEXT PRIMARY KEY,
+	devices_outdated BOOLEAN NOT NULL DEFAULT FALSE
 );
 
 CREATE TABLE IF NOT EXISTS crypto_device (

--- a/crypto/sql_store_upgrade/11-outdated-devices.sql
+++ b/crypto/sql_store_upgrade/11-outdated-devices.sql
@@ -1,0 +1,2 @@
+-- v11: Add devices_outdated field to crypto_tracked_user
+ALTER TABLE crypto_tracked_user ADD COLUMN devices_outdated BOOLEAN NOT NULL DEFAULT FALSE;


### PR DESCRIPTION
Many crypto operations in the Olm machine have a possible side effect of fetching keys from the server if they are missing. This may be undesired in some special cases.

To tracking which users need key fetching, CryptoStore now exposes APIs to mark and query the status.