### PR TITLE
Only skip fetching keys during Megolm decryption if disabled

### DIFF
--- a/crypto/decryptmegolm.go
+++ b/crypto/decryptmegolm.go
@@ -72,7 +72,11 @@ func (mach *OlmMachine) DecryptMegolmEvent(ctx context.Context, evt *event.Event
 	if sess.SigningKey == ownSigningKey && sess.SenderKey == ownIdentityKey && len(sess.ForwardingChains) == 0 {
 		trustLevel = id.TrustStateVerified
 	} else {
-		device, err = mach.GetOrFetchDeviceByKey(ctx, evt.Sender, sess.SenderKey)
+		if mach.DisableDecryptKeyFetching {
+			device, err = mach.CryptoStore.FindDeviceByKey(ctx, evt.Sender, sess.SenderKey)
+		} else {
+			device, err = mach.GetOrFetchDeviceByKey(ctx, evt.Sender, sess.SenderKey)
+		}
 		if err != nil {
 			// We don't want to throw these errors as the message can still be decrypted.
 			log.Debug().Err(err).Msg("Failed to get device to verify session")

--- a/crypto/keysharing.go
+++ b/crypto/keysharing.go
@@ -248,7 +248,7 @@ func (mach *OlmMachine) defaultAllowKeyShare(ctx context.Context, device *id.Dev
 	}
 }
 
-func (mach *OlmMachine) handleRoomKeyRequest(ctx context.Context, sender id.UserID, content *event.RoomKeyRequestEventContent) {
+func (mach *OlmMachine) HandleRoomKeyRequest(ctx context.Context, sender id.UserID, content *event.RoomKeyRequestEventContent) {
 	log := zerolog.Ctx(ctx).With().
 		Str("request_id", content.RequestID).
 		Str("device_id", content.RequestingDeviceID.String()).
@@ -327,7 +327,7 @@ func (mach *OlmMachine) handleRoomKeyRequest(ctx context.Context, sender id.User
 	}
 }
 
-func (mach *OlmMachine) handleBeeperRoomKeyAck(ctx context.Context, sender id.UserID, content *event.BeeperRoomKeyAckEventContent) {
+func (mach *OlmMachine) HandleBeeperRoomKeyAck(ctx context.Context, sender id.UserID, content *event.BeeperRoomKeyAckEventContent) {
 	log := mach.machOrContextLog(ctx).With().
 		Str("room_id", content.RoomID.String()).
 		Str("session_id", content.SessionID.String()).


### PR DESCRIPTION
Blanket disabling caused a lot of side effects which were hard to deal with without major refactoring.

This should probably be an argument to DecryptMegolm instead of a flag.