### PR TITLE
Share room keys to known devices on request

### DIFF
--- a/crypto/encryptmegolm.go
+++ b/crypto/encryptmegolm.go
@@ -330,6 +330,17 @@ func (mach *OlmMachine) encryptAndSendGroupSession(ctx context.Context, session 
 				Str("target_user_id", userID.String()).
 				Str("target_device_id", deviceID.String()).
 				Msg("Encrypted group session for device")
+			if !mach.DisableSharedGroupSessionTracking {
+				err := mach.CryptoStore.MarkOutboundGroupSessionShared(ctx, userID, device.identity.IdentityKey, session.id)
+				if err != nil {
+					log.Warn().
+						Err(err).
+						Str("target_user_id", userID.String()).
+						Str("target_device_id", deviceID.String()).
+						Stringer("target_session_id", session.id).
+						Msg("Failed to mark outbound group session shared")
+				}
+			}
 		}
 	}
 

--- a/crypto/machine.go
+++ b/crypto/machine.go
@@ -36,6 +36,9 @@ type OlmMachine struct {
 	// Never ask the server for keys automatically as a side effect during Megolm decryption.
 	DisableDecryptKeyFetching bool
 
+	// Don't mark outbound Olm sessions as shared for devices they were initially sent to.
+	DisableSharedGroupSessionTracking bool
+
 	SendKeysMinTrust  id.TrustState
 	ShareKeysMinTrust id.TrustState
 

--- a/crypto/sql_store_upgrade/00-latest-revision.sql
+++ b/crypto/sql_store_upgrade/00-latest-revision.sql
@@ -1,4 +1,4 @@
--- v0 -> v12 (compatible with v9+): Latest revision
+-- v0 -> v13 (compatible with v9+): Latest revision
 CREATE TABLE IF NOT EXISTS crypto_account (
 	account_id TEXT    PRIMARY KEY,
 	device_id  TEXT    NOT NULL,
@@ -73,6 +73,14 @@ CREATE TABLE IF NOT EXISTS crypto_megolm_outbound_session (
 	created_at    timestamp NOT NULL,
 	last_used     timestamp NOT NULL,
 	PRIMARY KEY (account_id, room_id)
+);
+
+CREATE TABLE IF NOT EXISTS crypto_megolm_outbound_session_shared (
+	user_id      TEXT     NOT NULL,
+	identity_key CHAR(43) NOT NULL,
+	session_id   CHAR(43) NOT NULL,
+
+	PRIMARY KEY (user_id, identity_key, session_id)
 );
 
 CREATE TABLE IF NOT EXISTS crypto_cross_signing_keys (

--- a/crypto/sql_store_upgrade/13-megolm-session-sharing.sql
+++ b/crypto/sql_store_upgrade/13-megolm-session-sharing.sql
@@ -1,0 +1,9 @@
+-- v13 (compatible with v9+): Add crypto_megolm_outbound_session_shared table
+
+CREATE TABLE IF NOT EXISTS crypto_megolm_outbound_session_shared (
+	user_id      TEXT     NOT NULL,
+	identity_key CHAR(43) NOT NULL,
+	session_id   CHAR(43) NOT NULL,
+
+	PRIMARY KEY (user_id, identity_key, session_id)
+);

--- a/crypto/store_test.go
+++ b/crypto/store_test.go
@@ -217,6 +217,62 @@ func TestStoreOutboundMegolmSession(t *testing.T) {
 	}
 }
 
+func TestStoreOutboundMegolmSessionSharing(t *testing.T) {
+	stores := getCryptoStores(t)
+
+	resetDevice := func() *id.Device {
+		acc := NewOlmAccount()
+		return &id.Device{
+			UserID:      "user1",
+			DeviceID:    id.DeviceID("dev1"),
+			IdentityKey: acc.IdentityKey(),
+			SigningKey:  acc.SigningKey(),
+		}
+	}
+
+	for storeName, store := range stores {
+		t.Run(storeName, func(t *testing.T) {
+			device := resetDevice()
+			err := store.PutDevice(context.TODO(), "user1", device)
+			if err != nil {
+				t.Errorf("Error storing devices: %v", err)
+			}
+
+			shared, err := store.IsOutboundGroupSessionShared(context.TODO(), device.UserID, device.IdentityKey, "session1")
+			if err != nil {
+				t.Errorf("Error checking if outbound group session is shared: %v", err)
+			} else if shared {
+				t.Errorf("Outbound group session shared when it shouldn't")
+			}
+
+			err = store.MarkOutboundGroupSessionShared(context.TODO(), device.UserID, device.IdentityKey, "session1")
+			if err != nil {
+				t.Errorf("Error marking outbound group session as shared: %v", err)
+			}
+
+			shared, err = store.IsOutboundGroupSessionShared(context.TODO(), device.UserID, device.IdentityKey, "session1")
+			if err != nil {
+				t.Errorf("Error checking if outbound group session is shared: %v", err)
+			} else if !shared {
+				t.Errorf("Outbound group session not shared when it should")
+			}
+
+			device = resetDevice()
+			err = store.PutDevice(context.TODO(), "user1", device)
+			if err != nil {
+				t.Errorf("Error storing devices: %v", err)
+			}
+
+			shared, err = store.IsOutboundGroupSessionShared(context.TODO(), device.UserID, device.IdentityKey, "session1")
+			if err != nil {
+				t.Errorf("Error checking if outbound group session is shared: %v", err)
+			} else if shared {
+				t.Errorf("Outbound group session shared when it shouldn't")
+			}
+		})
+	}
+}
+
 func TestStoreDevices(t *testing.T) {
 	stores := getCryptoStores(t)
 	for storeName, store := range stores {


### PR DESCRIPTION
This is currently naive and not secure. Mostly for RFC about the store interface and ideas how to invalidate devices.

Should we invalidate all shared sessions when the device identity changes on PutDevice(s) or have a separate function to invalidate a device or something completely different?

We could key the known shares with device identity and that would not require special invalidation but since the database has no foreign keys automatic invalidation is a bit hard regardless. Also as PutDevice(s) is an UPSERT we don't know if the identity changed or not unless PutDevice implicitly does GetDevice first to compare and then invalidate.