### PR TITLE
Add permission level to deny login-matrix

### DIFF
--- a/bridge/bridgeconfig/permissions.go
+++ b/bridge/bridgeconfig/permissions.go
@@ -20,13 +20,15 @@ type PermissionLevel int
 const (
 	PermissionLevelBlock PermissionLevel = 0
 	PermissionLevelRelay PermissionLevel = 5
-	PermissionLevelUser  PermissionLevel = 10
+	PermissionLevelLogin PermissionLevel = 10
+	PermissionLevelUser  PermissionLevel = 15
 	PermissionLevelAdmin PermissionLevel = 100
 )
 
 var namesToLevels = map[string]PermissionLevel{
 	"block": PermissionLevelBlock,
 	"relay": PermissionLevelRelay,
+	"login": PermissionLevelLogin,
 	"user":  PermissionLevelUser,
 	"admin": PermissionLevelAdmin,
 }

--- a/bridge/commands/doublepuppet.go
+++ b/bridge/commands/doublepuppet.go
@@ -14,6 +14,7 @@ var CommandLoginMatrix = &FullHandler{
 		Description: "Enable double puppeting.",
 		Args:        "<_access token_>",
 	},
+	RequiresLogin:           true,
 	RequiresMatrixPuppeting: true,
 }
 
@@ -45,6 +46,7 @@ var CommandPingMatrix = &FullHandler{
 		Section:     HelpSectionAuth,
 		Description: "Ping the Matrix server with the double puppet.",
 	},
+	RequiresLogin:           true,
 	RequiresMatrixPuppeting: true,
 }
 
@@ -69,6 +71,7 @@ var CommandLogoutMatrix = &FullHandler{
 		Section:     HelpSectionAuth,
 		Description: "Disable double puppeting.",
 	},
+	RequiresLogin:           true,
 	RequiresMatrixPuppeting: true,
 }
 

--- a/bridge/commands/doublepuppet.go
+++ b/bridge/commands/doublepuppet.go
@@ -14,7 +14,7 @@ var CommandLoginMatrix = &FullHandler{
 		Description: "Enable double puppeting.",
 		Args:        "<_access token_>",
 	},
-	RequiresLogin: true,
+	RequiresMatrixPuppeting: true,
 }
 
 func fnLoginMatrix(ce *Event) {
@@ -45,7 +45,7 @@ var CommandPingMatrix = &FullHandler{
 		Section:     HelpSectionAuth,
 		Description: "Ping the Matrix server with the double puppet.",
 	},
-	RequiresLogin: true,
+	RequiresMatrixPuppeting: true,
 }
 
 func fnPingMatrix(ce *Event) {
@@ -69,7 +69,7 @@ var CommandLogoutMatrix = &FullHandler{
 		Section:     HelpSectionAuth,
 		Description: "Disable double puppeting.",
 	},
-	RequiresLogin: true,
+	RequiresMatrixPuppeting: true,
 }
 
 func fnLogoutMatrix(ce *Event) {

--- a/bridge/commands/handler.go
+++ b/bridge/commands/handler.go
@@ -51,9 +51,10 @@ type FullHandler struct {
 	Aliases []string
 	Help    HelpMeta
 
-	RequiresAdmin  bool
-	RequiresPortal bool
-	RequiresLogin  bool
+	RequiresAdmin           bool
+	RequiresMatrixPuppeting bool
+	RequiresPortal          bool
+	RequiresLogin           bool
 
 	RequiresEventLevel event.Type
 }
@@ -71,8 +72,20 @@ func (fh *FullHandler) GetAliases() []string {
 	return fh.Aliases
 }
 
+func (fh *FullHandler) GetMinPermission() bridgeconfig.PermissionLevel {
+	if fh.RequiresAdmin {
+		return bridgeconfig.PermissionLevelAdmin
+	} else if fh.RequiresMatrixPuppeting {
+		return bridgeconfig.PermissionLevelUser
+	} else if fh.RequiresLogin {
+		return bridgeconfig.PermissionLevelLogin
+	} else {
+		return bridgeconfig.PermissionLevelBlock
+	}
+}
+
 func (fh *FullHandler) ShowInHelp(ce *Event) bool {
-	return !fh.RequiresAdmin || ce.User.GetPermissionLevel() >= bridgeconfig.PermissionLevelAdmin
+	return ce.User.GetPermissionLevel() >= fh.GetMinPermission()
 }
 
 func (fh *FullHandler) userHasRoomPermission(ce *Event) bool {
@@ -86,9 +99,14 @@ func (fh *FullHandler) userHasRoomPermission(ce *Event) bool {
 }
 
 func (fh *FullHandler) Run(ce *Event) {
-	if fh.RequiresAdmin && ce.User.GetPermissionLevel() < bridgeconfig.PermissionLevelAdmin {
+	permissionLevel := ce.User.GetPermissionLevel()
+	if fh.RequiresLogin && permissionLevel < bridgeconfig.PermissionLevelLogin {
+		ce.Reply("That command is limited to users with puppeting privileges.")
+	} else if fh.RequiresMatrixPuppeting && permissionLevel < bridgeconfig.PermissionLevelUser {
+		ce.Reply("That command is limited to users with full puppeting privileges.")
+	} else if fh.RequiresAdmin && permissionLevel < bridgeconfig.PermissionLevelAdmin {
 		ce.Reply("That command is limited to bridge administrators.")
-	} else if fh.RequiresEventLevel.Type != "" && ce.User.GetPermissionLevel() < bridgeconfig.PermissionLevelAdmin && !fh.userHasRoomPermission(ce) {
+	} else if fh.RequiresEventLevel.Type != "" && permissionLevel < bridgeconfig.PermissionLevelAdmin && !fh.userHasRoomPermission(ce) {
 		ce.Reply("That command requires room admin rights.")
 	} else if fh.RequiresPortal && ce.Portal == nil {
 		ce.Reply("That command can only be ran in portal rooms.")

--- a/bridge/commands/handler.go
+++ b/bridge/commands/handler.go
@@ -72,7 +72,7 @@ func (fh *FullHandler) GetAliases() []string {
 	return fh.Aliases
 }
 
-func (fh *FullHandler) GetMinPermission() bridgeconfig.PermissionLevel {
+func (fh *FullHandler) GetMinPermissionLevel() bridgeconfig.PermissionLevel {
 	if fh.RequiresAdmin {
 		return bridgeconfig.PermissionLevelAdmin
 	} else if fh.RequiresMatrixPuppeting {
@@ -85,7 +85,7 @@ func (fh *FullHandler) GetMinPermission() bridgeconfig.PermissionLevel {
 }
 
 func (fh *FullHandler) ShowInHelp(ce *Event) bool {
-	return ce.User.GetPermissionLevel() >= fh.GetMinPermission()
+	return ce.User.GetPermissionLevel() >= fh.GetMinPermissionLevel()
 }
 
 func (fh *FullHandler) userHasRoomPermission(ce *Event) bool {

--- a/bridge/matrix.go
+++ b/bridge/matrix.go
@@ -140,7 +140,7 @@ func (mx *MatrixHandler) HandleBotInvite(ctx context.Context, evt *event.Event) 
 		return
 	}
 
-	if user.GetPermissionLevel() < bridgeconfig.PermissionLevelUser {
+	if user.GetPermissionLevel() < bridgeconfig.PermissionLevelLogin {
 		_, _ = intent.SendNotice(ctx, evt.RoomID, "You are not whitelisted to use this bridge.\n"+
 			"If you're the owner of this bridge, see the bridge.permissions section in your config file.")
 		_, _ = intent.LeaveRoom(ctx, evt.RoomID)
@@ -174,7 +174,7 @@ func (mx *MatrixHandler) HandleGhostInvite(ctx context.Context, evt *event.Event
 	log := zerolog.Ctx(ctx)
 	intent := ghost.DefaultIntent()
 
-	if inviter.GetPermissionLevel() < bridgeconfig.PermissionLevelUser {
+	if inviter.GetPermissionLevel() < bridgeconfig.PermissionLevelLogin {
 		log.Debug().Msg("Rejecting invite: inviter is not whitelisted")
 		_, err := intent.LeaveRoom(ctx, evt.RoomID, &mautrix.ReqLeave{
 			Reason: "You're not whitelisted to use this bridge",
@@ -271,7 +271,7 @@ func (mx *MatrixHandler) HandleMembership(ctx context.Context, evt *event.Event)
 			mx.HandleGhostInvite(ctx, evt, user, ghost)
 		}
 		return
-	} else if user.GetPermissionLevel() < bridgeconfig.PermissionLevelUser || !user.IsLoggedIn() {
+	} else if user.GetPermissionLevel() < bridgeconfig.PermissionLevelLogin || !user.IsLoggedIn() {
 		return
 	}
 
@@ -568,7 +568,7 @@ func (mx *MatrixHandler) HandleMessage(ctx context.Context, evt *event.Event) {
 
 	content := evt.Content.AsMessage()
 	content.RemoveReplyFallback()
-	if user.GetPermissionLevel() >= bridgeconfig.PermissionLevelUser && content.MsgType == event.MsgText {
+	if user.GetPermissionLevel() >= bridgeconfig.PermissionLevelLogin && content.MsgType == event.MsgText {
 		commandPrefix := mx.bridge.Config.Bridge.GetCommandPrefix()
 		hasCommandPrefix := strings.HasPrefix(content.Body, commandPrefix)
 		if hasCommandPrefix {
@@ -610,7 +610,7 @@ func (mx *MatrixHandler) HandleReaction(_ context.Context, evt *event.Event) {
 	}
 
 	user := mx.bridge.Child.GetIUser(evt.Sender, true)
-	if user == nil || user.GetPermissionLevel() < bridgeconfig.PermissionLevelUser || !user.IsLoggedIn() {
+	if user == nil || user.GetPermissionLevel() < bridgeconfig.PermissionLevelLogin || !user.IsLoggedIn() {
 		return
 	}
 


### PR DESCRIPTION
as some instances may want to discourage users from sharing their Matrix access tokens.