### PR TITLE
changelog: add missing breaking change info for v0.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 * **Breaking change *(everything)*** Added context parameters to all functions
   (started by [@recht] in [#144]).
 * **Breaking change *(client)*** Moved `EventSource` to `event.Source`.
+* **Breaking change *(sync)*** The source parameter was removed on the `EventHandler` type.
 * *(client)* Removed deprecated `OldEventIgnorer`. The non-deprecated version
   (`Client.DontProcessOldEvents`) is still available.
 * *(crypto)* Added experimental pure Go Olm implementation to replace libolm


### PR DESCRIPTION
If I may, I struggled a bit to understand what was wrong in my code because of this change :sweat_smile:  It was done [in this commit](https://github.com/mautrix/go/commit/308e3583b06f03da67da38a5ff4d711cd5fa02d1).