### PR TITLE
Use the encoded form of megolm session key in backup session data

### DIFF
--- a/crypto/backup/megolmbackup.go
+++ b/crypto/backup/megolmbackup.go
@@ -35,5 +35,5 @@ type MegolmSessionData struct {
 	ForwardingKeyChain []string          `json:"forwarding_curve25519_key_chain"`
 	SenderClaimedKeys  SenderClaimedKeys `json:"sender_claimed_keys"`
 	SenderKey          id.SenderKey      `json:"sender_key"`
-	SessionKey         []byte            `json:"session_key"`
+	SessionKey         string            `json:"session_key"`
 }

--- a/crypto/keybackup.go
+++ b/crypto/keybackup.go
@@ -2,7 +2,6 @@ package crypto
 
 import (
 	"context"
-	"encoding/base64"
 	"fmt"
 	"time"
 
@@ -140,7 +139,7 @@ func (mach *OlmMachine) ImportRoomKeyFromBackup(ctx context.Context, version id.
 		return fmt.Errorf("ignoring room key in backup with weird algorithm %s", keyBackupData.Algorithm)
 	}
 
-	igsInternal, err := olm.InboundGroupSessionImport([]byte(base64.RawStdEncoding.EncodeToString(keyBackupData.SessionKey)))
+	igsInternal, err := olm.InboundGroupSessionImport([]byte(keyBackupData.SessionKey))
 	if err != nil {
 		return fmt.Errorf("failed to import inbound group session: %w", err)
 	} else if igsInternal.ID() != sessionID {


### PR DESCRIPTION
We're using the encoded presentation elsewhere as a string and this inconsistency is a footgun.