### PR TITLE
Invalidate memory cache when storing own cross-signing keys

### DIFF
--- a/crypto/cross_sign_store.go
+++ b/crypto/cross_sign_store.go
@@ -96,5 +96,12 @@ func (mach *OlmMachine) storeCrossSigningKeys(ctx context.Context, crossSigningK
 				}
 			}
 		}
+
+		// Clear internal cache so that it refreshes from crypto store
+		if userID == mach.Client.UserID && mach.crossSigningPubkeys != nil {
+			log.Debug().Msg("Resetting internal cross-signing key cache")
+			mach.crossSigningPubkeys = nil
+			mach.crossSigningPubkeysFetched = false
+		}
 	}
 }


### PR DESCRIPTION
When another device does cross-signing reset we would incorrectly cache the old keys indefinitely.