### PR TITLE
machine/ShareKeys: save keys before sending server request in case it fails

### DIFF
--- a/crypto/account.go
+++ b/crypto/account.go
@@ -81,6 +81,5 @@ func (account *OlmAccount) getOneTimeKeys(userID id.UserID, deviceID id.DeviceID
 		key.IsSigned = true
 		oneTimeKeys[id.NewKeyID(id.KeyAlgorithmSignedCurve25519, keyID)] = key
 	}
-	account.Internal.MarkKeysAsPublished()
 	return oneTimeKeys
 }

--- a/crypto/machine.go
+++ b/crypto/machine.go
@@ -681,6 +681,11 @@ func (mach *OlmMachine) ShareKeys(ctx context.Context, currentOTKCount int) erro
 		log.Debug().Msg("No one-time keys nor device keys got when trying to share keys")
 		return nil
 	}
+	// Save the keys before sending the upload request in case there is a
+	// network failure.
+	if err := mach.saveAccount(ctx); err != nil {
+		return err
+	}
 	req := &mautrix.ReqUploadKeys{
 		DeviceKeys:  deviceKeys,
 		OneTimeKeys: oneTimeKeys,
@@ -691,6 +696,7 @@ func (mach *OlmMachine) ShareKeys(ctx context.Context, currentOTKCount int) erro
 		return err
 	}
 	mach.lastOTKUpload = time.Now()
+	mach.account.Internal.MarkKeysAsPublished()
 	mach.account.Shared = true
 	return mach.saveAccount(ctx)
 }

--- a/crypto/machine_test.go
+++ b/crypto/machine_test.go
@@ -77,6 +77,7 @@ func TestOlmMachineOlmMegolmSessions(t *testing.T) {
 		otk = otkTmp
 		break
 	}
+	machineIn.account.Internal.MarkKeysAsPublished()
 
 	// create outbound olm session for sending machine using OTK
 	olmSession, err := machineOut.account.Internal.NewOutboundSession(machineIn.account.IdentityKey(), otk.Key)


### PR DESCRIPTION
Signed-off-by: Sumner Evans <sumner@beeper.com>
