### PR TITLE
Add email on account create/modify, add possibility to modify pushers

### DIFF
--- a/client.go
+++ b/client.go
@@ -2299,3 +2299,16 @@ func NewClient(homeserverURL string, userID id.UserID, accessToken string) (*Cli
 		Store: NewMemorySyncStore(),
 	}, nil
 }
+
+// SetPushers modifies the user pushers.
+//
+// https://spec.matrix.org/latest/client-server-api/#post_matrixclientv3pushersset
+func (cli *Client) SetPushers(ctx context.Context, req ReqSetPushers) error {
+	reqURL := cli.BuildClientURL("v3", "pushers", "set")
+	_, err := cli.MakeFullRequest(ctx, FullRequest{
+		Method:      http.MethodPost,
+		URL:         reqURL,
+		RequestJSON: &req,
+	})
+	return err
+}

--- a/requests.go
+++ b/requests.go
@@ -454,3 +454,20 @@ type ReqKeyBackupData struct {
 	IsVerified        bool            `json:"is_verified"`
 	SessionData       json.RawMessage `json:"session_data"`
 }
+
+type PushData struct {
+	Format string `json:"format"`
+	URL    string `json:"url"`
+}
+
+type ReqSetPushers struct {
+	AppDisplayName    string   `json:"app_display_name"`
+	AppID             string   `json:"app_id"`
+	Append            bool     `json:"append"`
+	Data              PushData `json:"data"`
+	DeviceDisplayName string   `json:"device_display_name"`
+	Kind              string   `json:"kind"`
+	Lang              string   `json:"lang"`
+	ProfileTag        string   `json:"profile_tag"`
+	PushKey           string   `json:"pushkey"`
+}

--- a/synapseadmin/userapi.go
+++ b/synapseadmin/userapi.go
@@ -126,6 +126,11 @@ func (cli *Client) DeactivateAccount(ctx context.Context, userID id.UserID, req 
 	return err
 }
 
+type Threepid struct {
+	Medium  string `json:"medium"`
+	Address string `json:"address"`
+}
+
 type ReqCreateOrModifyAccount struct {
 	Password      string `json:"password,omitempty"`
 	LogoutDevices *bool  `json:"logout_devices,omitempty"`
@@ -137,6 +142,8 @@ type ReqCreateOrModifyAccount struct {
 	Displayname string              `json:"displayname,omitempty"`
 	AvatarURL   id.ContentURIString `json:"avatar_url,omitempty"`
 	UserType    string              `json:"user_type,omitempty"`
+
+	Threepids []Threepid `json:"threepids,omitempty"`
 }
 
 // CreateOrModifyAccount creates or modifies an account on the server.


### PR DESCRIPTION
Possibility to add an email to the account when creating or modifying the account on the server.
Adds the possibility to modify pushers for the user.