### PR TITLE
verificationhelper: ensure that the keys are fetched before starting

### DIFF
--- a/crypto/devicelist.go
+++ b/crypto/devicelist.go
@@ -93,6 +93,10 @@ func (mach *OlmMachine) storeDeviceSelfSignatures(ctx context.Context, userID id
 	}
 }
 
+// FetchKeys fetches the devices of a list of other users. If includeUntracked
+// is set to false, then the users are filtered to to only include user IDs
+// whose device lists have been stored with the PutDevices function on the
+// [Store]. See the FilterTrackedUsers function on [Store] for details.
 func (mach *OlmMachine) FetchKeys(ctx context.Context, users []id.UserID, includeUntracked bool) (data map[id.UserID]map[id.DeviceID]*id.Device, err error) {
 	req := &mautrix.ReqQueryKeys{
 		DeviceKeys: mautrix.DeviceKeysRequest{},

--- a/crypto/verificationhelper/verificationhelper.go
+++ b/crypto/verificationhelper/verificationhelper.go
@@ -337,6 +337,12 @@ func (vh *VerificationHelper) StartVerification(ctx context.Context, to id.UserI
 	devices, err := vh.mach.CryptoStore.GetDevices(ctx, to)
 	if err != nil {
 		return "", fmt.Errorf("failed to get devices for user: %w", err)
+	} else if len(devices) == 0 {
+		// HACK: we are doing this because the client doesn't wait until it has
+		// the devices before starting verification.
+		if _, err := vh.mach.FetchKeys(ctx, []id.UserID{to}, true); err != nil {
+			return "", err
+		}
 	}
 
 	vh.getLog(ctx).Info().


### PR DESCRIPTION
Signed-off-by: Sumner Evans <sumner@beeper.com>
