### PR TITLE
crypto/olm: remove Signatures definition

### DIFF
--- a/crypto/olm/olm.go
+++ b/crypto/olm/olm.go
@@ -5,12 +5,6 @@ package olm
 // #cgo LDFLAGS: -lolm -lstdc++
 // #include <olm/olm.h>
 import "C"
-import (
-	"maunium.net/go/mautrix/id"
-)
-
-// Signatures is the data structure used to sign JSON objects.
-type Signatures map[id.UserID]map[id.DeviceKeyID]string
 
 // Version returns the version number of the olm library.
 func Version() (major, minor, patch uint8) {

--- a/crypto/olm/olm_goolm.go
+++ b/crypto/olm/olm_goolm.go
@@ -2,13 +2,6 @@
 
 package olm
 
-import (
-	"maunium.net/go/mautrix/id"
-)
-
-// Signatures is the data structure used to sign JSON objects.
-type Signatures map[id.UserID]map[id.DeviceKeyID]string
-
 // Version returns the version number of the olm library.
 func Version() (major, minor, patch uint8) {
 	return 3, 2, 15


### PR DESCRIPTION
This type doesn't seem to be referenced anywhere. We have the `crypto/signatures` module as well now.

Signed-off-by: Sumner Evans <sumner.evans@automattic.com>
