### PR TITLE
verificationhelper: fixes for when we are generating the QR code

### DIFF
--- a/crypto/verificationhelper/reciprocate.go
+++ b/crypto/verificationhelper/reciprocate.go
@@ -231,7 +231,7 @@ func (vh *VerificationHelper) generateAndShowQRCode(ctx context.Context, txn *ve
 	mode := QRCodeModeCrossSigning
 	if vh.client.UserID == txn.TheirUser {
 		// This is a self-signing situation.
-		if trusted, err := vh.mach.IsUserTrusted(ctx, vh.client.UserID); err != nil {
+		if trusted, err := vh.mach.CryptoStore.IsKeySignedBy(ctx, vh.client.UserID, ownCrossSigningPublicKeys.MasterKey, vh.client.UserID, vh.mach.OwnIdentity().SigningKey); err != nil {
 			return err
 		} else if trusted {
 			mode = QRCodeModeSelfVerifyingMasterKeyTrusted

--- a/crypto/verificationhelper/reciprocate.go
+++ b/crypto/verificationhelper/reciprocate.go
@@ -76,6 +76,9 @@ func (vh *VerificationHelper) HandleScannedQRData(ctx context.Context, data []by
 			return fmt.Errorf("the other device has the wrong key for this device")
 		}
 
+		if err := vh.mach.SignOwnMasterKey(ctx); err != nil {
+			return fmt.Errorf("failed to sign own master key: %w", err)
+		}
 	case QRCodeModeSelfVerifyingMasterKeyUntrusted:
 		// The QR was created by a device that does not trust the master key,
 		// which means that we do trust the master key. Key1 is the other
@@ -192,8 +195,10 @@ func (vh *VerificationHelper) ConfirmQRCodeScanned(ctx context.Context, txnID id
 				return fmt.Errorf("failed to sign their device: %w", err)
 			}
 		}
+	} else {
+		// TODO: handle QR codes that are not self-signing situations
+		panic("unimplemented")
 	}
-	// TODO: handle QR codes that are not self-signing situations
 
 	err := vh.sendVerificationEvent(ctx, txn, event.InRoomVerificationDone, &event.VerificationDoneEventContent{})
 	if err != nil {


### PR DESCRIPTION
This PR fixes issues when the device generating the QR code does not trust the master key.
