### PR TITLE
verificationhelper: add E2E tests and fix QR code generation and verification logic

### DIFF
--- a/crypto/verificationhelper/callbacks_test.go
+++ b/crypto/verificationhelper/callbacks_test.go
@@ -1,0 +1,136 @@
+// Copyright (c) 2024 Sumner Evans
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package verificationhelper_test
+
+import (
+	"context"
+
+	"maunium.net/go/mautrix/crypto/verificationhelper"
+	"maunium.net/go/mautrix/event"
+	"maunium.net/go/mautrix/id"
+)
+
+type MockVerificationCallbacks interface {
+	GetRequestedVerifications() map[id.UserID][]id.VerificationTransactionID
+	GetScanQRCodeTransactions() []id.VerificationTransactionID
+	GetQRCodeShown(id.VerificationTransactionID) *verificationhelper.QRCode
+}
+
+type baseVerificationCallbacks struct {
+	scanQRCodeTransactions   []id.VerificationTransactionID
+	verificationsRequested   map[id.UserID][]id.VerificationTransactionID
+	qrCodesShown             map[id.VerificationTransactionID]*verificationhelper.QRCode
+	qrCodesScanned           map[id.VerificationTransactionID]struct{}
+	doneTransactions         map[id.VerificationTransactionID]struct{}
+	verificationCancellation map[id.VerificationTransactionID]*event.VerificationCancelEventContent
+}
+
+func newBaseVerificationCallbacks() *baseVerificationCallbacks {
+	return &baseVerificationCallbacks{
+		verificationsRequested:   map[id.UserID][]id.VerificationTransactionID{},
+		qrCodesShown:             map[id.VerificationTransactionID]*verificationhelper.QRCode{},
+		qrCodesScanned:           map[id.VerificationTransactionID]struct{}{},
+		doneTransactions:         map[id.VerificationTransactionID]struct{}{},
+		verificationCancellation: map[id.VerificationTransactionID]*event.VerificationCancelEventContent{},
+	}
+}
+
+func (c *baseVerificationCallbacks) GetRequestedVerifications() map[id.UserID][]id.VerificationTransactionID {
+	return c.verificationsRequested
+}
+
+func (c *baseVerificationCallbacks) GetScanQRCodeTransactions() []id.VerificationTransactionID {
+	return c.scanQRCodeTransactions
+}
+
+func (c *baseVerificationCallbacks) GetQRCodeShown(txnID id.VerificationTransactionID) *verificationhelper.QRCode {
+	return c.qrCodesShown[txnID]
+}
+
+func (c *baseVerificationCallbacks) WasOurQRCodeScanned(txnID id.VerificationTransactionID) bool {
+	_, ok := c.qrCodesScanned[txnID]
+	return ok
+}
+
+func (c *baseVerificationCallbacks) IsVerificationDone(txnID id.VerificationTransactionID) bool {
+	_, ok := c.doneTransactions[txnID]
+	return ok
+}
+
+func (c *baseVerificationCallbacks) GetVerificationCancellation(txnID id.VerificationTransactionID) *event.VerificationCancelEventContent {
+	return c.verificationCancellation[txnID]
+}
+
+func (c *baseVerificationCallbacks) VerificationRequested(ctx context.Context, txnID id.VerificationTransactionID, from id.UserID) {
+	c.verificationsRequested[from] = append(c.verificationsRequested[from], txnID)
+}
+
+func (c *baseVerificationCallbacks) VerificationCancelled(ctx context.Context, txnID id.VerificationTransactionID, code event.VerificationCancelCode, reason string) {
+	c.verificationCancellation[txnID] = &event.VerificationCancelEventContent{
+		Code:   code,
+		Reason: reason,
+	}
+}
+
+func (c *baseVerificationCallbacks) VerificationDone(ctx context.Context, txnID id.VerificationTransactionID) {
+	c.doneTransactions[txnID] = struct{}{}
+}
+
+type sasVerificationCallbacks struct {
+	*baseVerificationCallbacks
+}
+
+func newSASVerificationCallbacks() *sasVerificationCallbacks {
+	return &sasVerificationCallbacks{newBaseVerificationCallbacks()}
+}
+
+func newSASVerificationCallbacksWithBase(base *baseVerificationCallbacks) *sasVerificationCallbacks {
+	return &sasVerificationCallbacks{base}
+}
+
+func (*sasVerificationCallbacks) ShowSAS(ctx context.Context, txnID id.VerificationTransactionID, emojis []rune, decimals []int) {
+	panic("show sas")
+}
+
+type qrCodeVerificationCallbacks struct {
+	*baseVerificationCallbacks
+}
+
+func newQRCodeVerificationCallbacks() *qrCodeVerificationCallbacks {
+	return &qrCodeVerificationCallbacks{newBaseVerificationCallbacks()}
+}
+
+func newQRCodeVerificationCallbacksWithBase(base *baseVerificationCallbacks) *qrCodeVerificationCallbacks {
+	return &qrCodeVerificationCallbacks{base}
+}
+
+func (c *qrCodeVerificationCallbacks) ScanQRCode(ctx context.Context, txnID id.VerificationTransactionID) {
+	c.scanQRCodeTransactions = append(c.scanQRCodeTransactions, txnID)
+}
+
+func (c *qrCodeVerificationCallbacks) ShowQRCode(ctx context.Context, txnID id.VerificationTransactionID, qrCode *verificationhelper.QRCode) {
+	c.qrCodesShown[txnID] = qrCode
+}
+
+func (c *qrCodeVerificationCallbacks) QRCodeScanned(ctx context.Context, txnID id.VerificationTransactionID) {
+	c.qrCodesScanned[txnID] = struct{}{}
+}
+
+type allVerificationCallbacks struct {
+	*baseVerificationCallbacks
+	*sasVerificationCallbacks
+	*qrCodeVerificationCallbacks
+}
+
+func newAllVerificationCallbacks() *allVerificationCallbacks {
+	base := newBaseVerificationCallbacks()
+	return &allVerificationCallbacks{
+		base,
+		newSASVerificationCallbacksWithBase(base),
+		newQRCodeVerificationCallbacksWithBase(base),
+	}
+}

--- a/crypto/verificationhelper/mockserver_test.go
+++ b/crypto/verificationhelper/mockserver_test.go
@@ -1,0 +1,248 @@
+// Copyright (c) 2024 Sumner Evans
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package verificationhelper_test
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/require"
+	"go.mau.fi/util/random"
+
+	"maunium.net/go/mautrix"
+	"maunium.net/go/mautrix/crypto"
+	"maunium.net/go/mautrix/crypto/cryptohelper"
+	"maunium.net/go/mautrix/event"
+	"maunium.net/go/mautrix/id"
+)
+
+// mockServer is a mock Matrix server that wraps an [httptest.Server] to allow
+// testing of the interactive verification process.
+type mockServer struct {
+	*httptest.Server
+
+	AccessTokenToUserID map[string]id.UserID
+	DeviceInbox         map[id.UserID]map[id.DeviceID][]event.Event
+	AccountData         map[id.UserID]map[event.Type]json.RawMessage
+	DeviceKeys          map[id.UserID]map[id.DeviceID]mautrix.DeviceKeys
+	MasterKeys          map[id.UserID]mautrix.CrossSigningKeys
+	SelfSigningKeys     map[id.UserID]mautrix.CrossSigningKeys
+	UserSigningKeys     map[id.UserID]mautrix.CrossSigningKeys
+}
+
+func DecodeVarsMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		vars := mux.Vars(r)
+		var err error
+		for k, v := range vars {
+			vars[k], err = url.PathUnescape(v)
+			if err != nil {
+				panic(err)
+			}
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+func createMockServer(t *testing.T) *mockServer {
+	t.Helper()
+
+	server := mockServer{
+		AccessTokenToUserID: map[string]id.UserID{},
+		DeviceInbox:         map[id.UserID]map[id.DeviceID][]event.Event{},
+		AccountData:         map[id.UserID]map[event.Type]json.RawMessage{},
+		DeviceKeys:          map[id.UserID]map[id.DeviceID]mautrix.DeviceKeys{},
+		MasterKeys:          map[id.UserID]mautrix.CrossSigningKeys{},
+		SelfSigningKeys:     map[id.UserID]mautrix.CrossSigningKeys{},
+		UserSigningKeys:     map[id.UserID]mautrix.CrossSigningKeys{},
+	}
+
+	router := mux.NewRouter().SkipClean(true).StrictSlash(false).UseEncodedPath()
+	router.Use(DecodeVarsMiddleware)
+	router.HandleFunc("/_matrix/client/v3/login", server.postLogin).Methods(http.MethodPost)
+	router.HandleFunc("/_matrix/client/v3/keys/query", server.postKeysQuery).Methods(http.MethodPost)
+	router.HandleFunc("/_matrix/client/v3/sendToDevice/{type}/{txn}", server.putSendToDevice).Methods(http.MethodPut)
+	router.HandleFunc("/_matrix/client/v3/user/{userID}/account_data/{type}", server.putAccountData).Methods(http.MethodPut)
+	router.HandleFunc("/_matrix/client/v3/keys/device_signing/upload", server.postDeviceSigningUpload).Methods(http.MethodPost)
+	router.HandleFunc("/_matrix/client/v3/keys/signatures/upload", server.emptyResp).Methods(http.MethodPost)
+	router.HandleFunc("/_matrix/client/v3/keys/upload", server.postKeysUpload).Methods(http.MethodPost)
+
+	server.Server = httptest.NewServer(router)
+	return &server
+}
+
+func (ms *mockServer) getUserID(r *http.Request) id.UserID {
+	authHeader := r.Header.Get("Authorization")
+	authHeader = strings.TrimPrefix(authHeader, "Bearer ")
+	userID, ok := ms.AccessTokenToUserID[authHeader]
+	if !ok {
+		panic("no user ID found for access token " + authHeader)
+	}
+	return userID
+}
+
+func (s *mockServer) emptyResp(w http.ResponseWriter, _ *http.Request) {
+	w.Write([]byte("{}"))
+}
+
+func (s *mockServer) postLogin(w http.ResponseWriter, r *http.Request) {
+	var loginReq mautrix.ReqLogin
+	json.NewDecoder(r.Body).Decode(&loginReq)
+
+	deviceID := loginReq.DeviceID
+	if deviceID == "" {
+		deviceID = id.DeviceID(random.String(10))
+	}
+
+	accessToken := random.String(30)
+	userID := id.UserID(loginReq.Identifier.User)
+	s.AccessTokenToUserID[accessToken] = userID
+
+	json.NewEncoder(w).Encode(&mautrix.RespLogin{
+		AccessToken: accessToken,
+		DeviceID:    deviceID,
+		UserID:      userID,
+	})
+}
+
+func (s *mockServer) putSendToDevice(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	var req mautrix.ReqSendToDevice
+	json.NewDecoder(r.Body).Decode(&req)
+	evtType := event.Type{Type: vars["type"], Class: event.ToDeviceEventType}
+
+	for user, devices := range req.Messages {
+		for device, content := range devices {
+			if _, ok := s.DeviceInbox[user]; !ok {
+				s.DeviceInbox[user] = map[id.DeviceID][]event.Event{}
+			}
+			content.ParseRaw(evtType)
+			s.DeviceInbox[user][device] = append(s.DeviceInbox[user][device], event.Event{
+				Sender:  s.getUserID(r),
+				Type:    evtType,
+				Content: *content,
+			})
+		}
+	}
+	s.emptyResp(w, r)
+}
+
+func (s *mockServer) putAccountData(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	userID := id.UserID(vars["userID"])
+	eventType := event.Type{Type: vars["type"], Class: event.AccountDataEventType}
+
+	jsonData, _ := io.ReadAll(r.Body)
+	if _, ok := s.AccountData[userID]; !ok {
+		s.AccountData[userID] = map[event.Type]json.RawMessage{}
+	}
+	s.AccountData[userID][eventType] = json.RawMessage(jsonData)
+	s.emptyResp(w, r)
+}
+
+func (s *mockServer) postKeysQuery(w http.ResponseWriter, r *http.Request) {
+	var req mautrix.ReqQueryKeys
+	json.NewDecoder(r.Body).Decode(&req)
+	resp := mautrix.RespQueryKeys{
+		MasterKeys:      map[id.UserID]mautrix.CrossSigningKeys{},
+		UserSigningKeys: map[id.UserID]mautrix.CrossSigningKeys{},
+		SelfSigningKeys: map[id.UserID]mautrix.CrossSigningKeys{},
+		DeviceKeys:      map[id.UserID]map[id.DeviceID]mautrix.DeviceKeys{},
+	}
+	for user := range req.DeviceKeys {
+		resp.MasterKeys[user] = s.MasterKeys[user]
+		resp.UserSigningKeys[user] = s.UserSigningKeys[user]
+		resp.SelfSigningKeys[user] = s.SelfSigningKeys[user]
+		resp.DeviceKeys[user] = s.DeviceKeys[user]
+	}
+	json.NewEncoder(w).Encode(&resp)
+}
+
+func (s *mockServer) postKeysUpload(w http.ResponseWriter, r *http.Request) {
+	var req mautrix.ReqUploadKeys
+	json.NewDecoder(r.Body).Decode(&req)
+
+	userID := s.getUserID(r)
+	if _, ok := s.DeviceKeys[userID]; !ok {
+		s.DeviceKeys[userID] = map[id.DeviceID]mautrix.DeviceKeys{}
+	}
+	s.DeviceKeys[userID][req.DeviceKeys.DeviceID] = *req.DeviceKeys
+
+	json.NewEncoder(w).Encode(&mautrix.RespUploadKeys{
+		OneTimeKeyCounts: mautrix.OTKCount{SignedCurve25519: 50},
+	})
+}
+
+func (s *mockServer) postDeviceSigningUpload(w http.ResponseWriter, r *http.Request) {
+	var req mautrix.UploadCrossSigningKeysReq
+	json.NewDecoder(r.Body).Decode(&req)
+
+	userID := s.getUserID(r)
+	s.MasterKeys[userID] = req.Master
+	s.SelfSigningKeys[userID] = req.SelfSigning
+	s.UserSigningKeys[userID] = req.UserSigning
+
+	s.emptyResp(w, r)
+}
+
+func (ms *mockServer) Login(t *testing.T, ctx context.Context, userID id.UserID, deviceID id.DeviceID) (*mautrix.Client, crypto.Store) {
+	t.Helper()
+	client, err := mautrix.NewClient(ms.URL, "", "")
+	require.NoError(t, err)
+	client.StateStore = mautrix.NewMemoryStateStore()
+
+	_, err = client.Login(ctx, &mautrix.ReqLogin{
+		Type: mautrix.AuthTypePassword,
+		Identifier: mautrix.UserIdentifier{
+			Type: mautrix.IdentifierTypeUser,
+			User: userID.String(),
+		},
+		DeviceID:         deviceID,
+		Password:         "password",
+		StoreCredentials: true,
+	})
+	require.NoError(t, err)
+
+	cryptoStore := crypto.NewMemoryStore(nil)
+	cryptoHelper, err := cryptohelper.NewCryptoHelper(client, []byte("test"), cryptoStore)
+	require.NoError(t, err)
+	client.Crypto = cryptoHelper
+
+	err = cryptoHelper.Init(ctx)
+	require.NoError(t, err)
+
+	err = cryptoHelper.Machine().ShareKeys(ctx, 50)
+	require.NoError(t, err)
+
+	return client, cryptoStore
+}
+
+func (ms *mockServer) dispatchToDevice(t *testing.T, ctx context.Context, client *mautrix.Client) {
+	t.Helper()
+
+	for _, evt := range ms.DeviceInbox[client.UserID][client.DeviceID] {
+		client.Syncer.(*mautrix.DefaultSyncer).Dispatch(ctx, &evt)
+		ms.DeviceInbox[client.UserID][client.DeviceID] = ms.DeviceInbox[client.UserID][client.DeviceID][1:]
+	}
+}
+
+func addDeviceID(ctx context.Context, cryptoStore crypto.Store, userID id.UserID, deviceID id.DeviceID) {
+	err := cryptoStore.PutDevice(ctx, userID, &id.Device{
+		UserID:   userID,
+		DeviceID: deviceID,
+	})
+	if err != nil {
+		panic(err)
+	}
+}

--- a/crypto/verificationhelper/qrcode_test.go
+++ b/crypto/verificationhelper/qrcode_test.go
@@ -8,51 +8,76 @@ package verificationhelper_test
 
 import (
 	"bytes"
+	"encoding/base64"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"maunium.net/go/mautrix/crypto/verificationhelper"
+	"maunium.net/go/mautrix/id"
 )
 
 func TestQRCode_Roundtrip(t *testing.T) {
 	var key1, key2 [32]byte
 	copy(key1[:], bytes.Repeat([]byte{0x01}, 32))
 	copy(key2[:], bytes.Repeat([]byte{0x02}, 32))
-	qrCode := verificationhelper.NewQRCode(verificationhelper.QRCodeModeCrossSigning, "test", key1, key2)
+	txnID := id.VerificationTransactionID(strings.Repeat("a", 20))
+	qrCode := verificationhelper.NewQRCode(verificationhelper.QRCodeModeCrossSigning, txnID, key1, key2)
 
 	encoded := qrCode.Bytes()
 	decoded, err := verificationhelper.NewQRCodeFromBytes(encoded)
 	require.NoError(t, err)
 
 	assert.Equal(t, verificationhelper.QRCodeModeCrossSigning, decoded.Mode)
-	assert.EqualValues(t, "test", decoded.TransactionID)
+	assert.EqualValues(t, txnID, decoded.TransactionID)
 	assert.Equal(t, key1, decoded.Key1)
 	assert.Equal(t, key2, decoded.Key2)
 }
 
 func TestQRCodeDecode(t *testing.T) {
-	qrcodeData := []byte{
-		0x4d, 0x41, 0x54, 0x52, 0x49, 0x58, 0x02, 0x01, 0x00, 0x20, 0x47, 0x6e, 0x41, 0x65, 0x43, 0x76,
-		0x74, 0x57, 0x6a, 0x7a, 0x4d, 0x4f, 0x56, 0x57, 0x51, 0x54, 0x6b, 0x74, 0x33, 0x35, 0x59, 0x52,
-		0x55, 0x72, 0x75, 0x6a, 0x6d, 0x52, 0x50, 0x63, 0x38, 0x61, 0x18, 0x32, 0x7c, 0xc3, 0x8c, 0xc2,
-		0xa6, 0xc2, 0xb5, 0xc2, 0xa7, 0x50, 0x57, 0x67, 0x19, 0x5e, 0xc3, 0xaf, 0xc2, 0xa0, 0xc2, 0x98,
-		0xc2, 0x9d, 0x36, 0xc3, 0xad, 0x7a, 0x10, 0x2e, 0x18, 0x3e, 0x4e, 0xc3, 0x84, 0xc3, 0x81, 0x45,
-		0x0c, 0xc2, 0xae, 0x19, 0x78, 0xc2, 0x99, 0x06, 0xc2, 0x92, 0xc2, 0x94, 0xc2, 0x8e, 0xc2, 0xb7,
-		0x59, 0xc2, 0x96, 0xc2, 0xad, 0xc3, 0xbd, 0x70, 0x6a, 0x11, 0xc2, 0xba, 0xc2, 0xa9, 0x29, 0xc3,
-		0x8f, 0x0d, 0xc2, 0xb8, 0xc2, 0x88, 0x67, 0x5b, 0xc3, 0xb3, 0x01, 0xc2, 0xb0, 0x63, 0x2e, 0xc2,
-		0xa5, 0xc3, 0xb3, 0x60, 0xc3, 0x82, 0x04, 0xc3, 0xa3, 0x72, 0x7d, 0x7c, 0x1d, 0xc2, 0xb6, 0xc2,
-		0xba, 0xc2, 0x81, 0x1e, 0xc2, 0x99, 0xc2, 0xb8, 0x7f, 0x0a,
+	testCases := []struct {
+		b64          string
+		txnID        string
+		key1         string
+		key2         string
+		sharedSecret string
+	}{
+		{
+			"TUFUUklYAgEAIEduQWVDdnRXanpNT1ZXUVRrdDM1WVJVcnVqbVJQYzhhGDJ8w4zCpsK1wqdQV2cZXsOvwqDCmMKdNsOtehAuGD5Ow4TDgUUMwq4ZeMKZBsKSwpTCjsK3WcKWwq3DvXBqEcK6wqkpw48NwrjCiGdbw7MBwrBjLsKlw7Ngw4IEw6NyfXwdwrbCusKBHsKZwrh/Cg==",
+			"GnAeCvtWjzMOVWQTkt35YRUrujmRPc8a",
+			"GDJ8w4zCpsK1wqdQV2cZXsOvwqDCmMKdNsOtehAuGD4=",
+			"TsOEw4FFDMKuGXjCmQbCksKUwo7Ct1nClsKtw71wahE=",
+			"wrrCqSnDjw3CuMKIZ1vDswHCsGMuwqXDs2DDggTDo3J9fB3CtsK6woEewpnCuH8K",
+		},
+		{
+			"TUFUUklYAgEAIGM1YjljNzE3ZWIzYjRmYzBiZDhhZjA0MDQ4NDY5MDdle4oLkpUdO1cTu5M3K3B4BlnpxtAbVgXCuQKOIqMmt+xAjVvaEXF39X0z5waRY9UE0b5PKiWvOBSJHEGkxX28Y2OEDLIWP/kCVUlyXXENlj0=",
+			"c5b9c717eb3b4fc0bd8af0404846907e",
+			"e4oLkpUdO1cTu5M3K3B4BlnpxtAbVgXCuQKOIqMmt+w=",
+			"QI1b2hFxd/V9M+cGkWPVBNG+TyolrzgUiRxBpMV9vGM=",
+			"Y4QMshY/+QJVSXJdcQ2WPQ==",
+		},
 	}
-	decoded, err := verificationhelper.NewQRCodeFromBytes(qrcodeData)
-	require.NoError(t, err)
-	assert.Equal(t, verificationhelper.QRCodeModeSelfVerifyingMasterKeyTrusted, decoded.Mode)
-	assert.EqualValues(t, "GnAeCvtWjzMOVWQTkt35YRUrujmRPc8a", decoded.TransactionID)
-	assert.Equal(t,
-		[32]byte{0x18, 0x32, 0x7c, 0xc3, 0x8c, 0xc2, 0xa6, 0xc2, 0xb5, 0xc2, 0xa7, 0x50, 0x57, 0x67, 0x19, 0x5e, 0xc3, 0xaf, 0xc2, 0xa0, 0xc2, 0x98, 0xc2, 0x9d, 0x36, 0xc3, 0xad, 0x7a, 0x10, 0x2e, 0x18, 0x3e},
-		decoded.Key1)
-	assert.Equal(t,
-		[32]byte{0x4e, 0xc3, 0x84, 0xc3, 0x81, 0x45, 0xc, 0xc2, 0xae, 0x19, 0x78, 0xc2, 0x99, 0x6, 0xc2, 0x92, 0xc2, 0x94, 0xc2, 0x8e, 0xc2, 0xb7, 0x59, 0xc2, 0x96, 0xc2, 0xad, 0xc3, 0xbd, 0x70, 0x6a, 0x11},
-		decoded.Key2)
+
+	for _, tc := range testCases {
+		t.Run(tc.b64, func(t *testing.T) {
+			qrcodeData, err := base64.StdEncoding.DecodeString(tc.b64)
+			require.NoError(t, err)
+			expectedKey1, err := base64.StdEncoding.DecodeString(tc.key1)
+			require.NoError(t, err)
+			expectedKey2, err := base64.StdEncoding.DecodeString(tc.key2)
+			require.NoError(t, err)
+			expectedSharedSecret, err := base64.StdEncoding.DecodeString(tc.sharedSecret)
+			require.NoError(t, err)
+
+			decoded, err := verificationhelper.NewQRCodeFromBytes(qrcodeData)
+			require.NoError(t, err)
+			assert.Equal(t, verificationhelper.QRCodeModeSelfVerifyingMasterKeyTrusted, decoded.Mode)
+			assert.EqualValues(t, tc.txnID, decoded.TransactionID)
+			assert.EqualValues(t, expectedKey1, decoded.Key1)
+			assert.EqualValues(t, expectedKey2, decoded.Key2)
+			assert.EqualValues(t, expectedSharedSecret, decoded.SharedSecret)
+		})
+	}
 }

--- a/crypto/verificationhelper/reciprocate.go
+++ b/crypto/verificationhelper/reciprocate.go
@@ -103,7 +103,7 @@ func (vh *VerificationHelper) HandleScannedQRData(ctx context.Context, data []by
 		}
 
 		// Verify that the other device's key is what we expect.
-		if bytes.Equal(theirDevice.IdentityKey.Bytes(), qrCode.Key1[:]) {
+		if bytes.Equal(theirDevice.SigningKey.Bytes(), qrCode.Key1[:]) {
 			log.Info().Msg("Verified that the other device key is what we expected")
 		} else {
 			return fmt.Errorf("the other device's key is not what we expected")
@@ -268,10 +268,10 @@ func (vh *VerificationHelper) generateAndShowQRCode(ctx context.Context, txn *ve
 		if err != nil {
 			return err
 		}
-		key2 = theirDevice.IdentityKey.Bytes()
+		key2 = theirDevice.SigningKey.Bytes()
 	case QRCodeModeSelfVerifyingMasterKeyUntrusted:
 		// Key 1 is the current device's key
-		key1 = vh.mach.OwnIdentity().IdentityKey.Bytes()
+		key1 = vh.mach.OwnIdentity().SigningKey.Bytes()
 
 		// Key 2 is the master signing key.
 		key2 = ownCrossSigningPublicKeys.MasterKey.Bytes()

--- a/crypto/verificationhelper/reciprocate.go
+++ b/crypto/verificationhelper/reciprocate.go
@@ -174,8 +174,7 @@ func (vh *VerificationHelper) ConfirmQRCodeScanned(ctx context.Context, txnID id
 		log.Warn().Msg("Ignoring QR code scan confirmation for an unknown transaction")
 		return nil
 	} else if txn.VerificationState != verificationStateOurQRScanned {
-		log.Warn().Msg("Ignoring QR code scan confirmation for a transaction that is not in the started state")
-		return nil
+		return fmt.Errorf("transaction is not in the scanned state")
 	}
 
 	log.Info().Msg("Confirming QR code scanned")

--- a/crypto/verificationhelper/sas.go
+++ b/crypto/verificationhelper/sas.go
@@ -580,7 +580,7 @@ func (vh *VerificationHelper) onVerificationMAC(ctx context.Context, txn *verifi
 	slices.Sort(keyIDs)
 	expectedKeyMAC, err := vh.verificationMACHKDF(txn, txn.TheirUser, txn.TheirDevice, vh.client.UserID, vh.client.DeviceID, "KEY_IDS", strings.Join(keyIDs, ","))
 	if err != nil {
-		vh.cancelVerificationTxn(ctx, txn, event.VerificationCancelCodeSASMismatch, "failed to calculate key list MAC: %v", err)
+		vh.cancelVerificationTxn(ctx, txn, event.VerificationCancelCodeSASMismatch, "failed to calculate key list MAC: %w", err)
 		return
 	}
 	if !bytes.Equal(expectedKeyMAC, macEvt.Keys) {
@@ -607,7 +607,7 @@ func (vh *VerificationHelper) onVerificationMAC(ctx context.Context, txn *verifi
 		if kID == txn.TheirDevice.String() {
 			theirDevice, err = vh.mach.GetOrFetchDevice(ctx, txn.TheirUser, txn.TheirDevice)
 			if err != nil {
-				vh.cancelVerificationTxn(ctx, txn, event.VerificationCancelCodeUser, "failed to fetch their device: %v", err)
+				vh.cancelVerificationTxn(ctx, txn, event.VerificationCancelCodeUser, "failed to fetch their device: %w", err)
 				return
 			}
 			key = theirDevice.SigningKey.String()
@@ -626,7 +626,7 @@ func (vh *VerificationHelper) onVerificationMAC(ctx context.Context, txn *verifi
 
 		expectedMAC, err := vh.verificationMACHKDF(txn, txn.TheirUser, txn.TheirDevice, vh.client.UserID, vh.client.DeviceID, keyID.String(), key)
 		if err != nil {
-			vh.cancelVerificationTxn(ctx, txn, event.VerificationCancelCodeUser, "failed to calculate key MAC: %v", err)
+			vh.cancelVerificationTxn(ctx, txn, event.VerificationCancelCodeUser, "failed to calculate key MAC: %w", err)
 			return
 		}
 		if !bytes.Equal(expectedMAC, mac) {
@@ -639,7 +639,7 @@ func (vh *VerificationHelper) onVerificationMAC(ctx context.Context, txn *verifi
 			theirDevice.Trust = id.TrustStateVerified
 			err = vh.mach.CryptoStore.PutDevice(ctx, txn.TheirUser, theirDevice)
 			if err != nil {
-				vh.cancelVerificationTxn(ctx, txn, event.VerificationCancelCodeUser, "failed to update device trust state after verifying: %v", err)
+				vh.cancelVerificationTxn(ctx, txn, event.VerificationCancelCodeUser, "failed to update device trust state after verifying: %w", err)
 				return
 			}
 		}
@@ -653,7 +653,7 @@ func (vh *VerificationHelper) onVerificationMAC(ctx context.Context, txn *verifi
 		txn.VerificationState = verificationStateSASMACExchanged
 		err := vh.sendVerificationEvent(ctx, txn, event.InRoomVerificationDone, &event.VerificationDoneEventContent{})
 		if err != nil {
-			vh.cancelVerificationTxn(ctx, txn, event.VerificationCancelCodeUser, "failed to send verification done event: %v", err)
+			vh.cancelVerificationTxn(ctx, txn, event.VerificationCancelCodeUser, "failed to send verification done event: %w", err)
 			return
 		}
 		txn.SentOurDone = true

--- a/crypto/verificationhelper/verificationhelper.go
+++ b/crypto/verificationhelper/verificationhelper.go
@@ -755,9 +755,9 @@ func (vh *VerificationHelper) onVerificationDone(ctx context.Context, txn *verif
 		return
 	}
 
-	txn.VerificationState = verificationStateDone
 	txn.ReceivedTheirDone = true
 	if txn.SentOurDone {
+		txn.VerificationState = verificationStateDone
 		vh.verificationDone(ctx, txn.TransactionID)
 	}
 }

--- a/crypto/verificationhelper/verificationhelper_self_test.go
+++ b/crypto/verificationhelper/verificationhelper_self_test.go
@@ -1,0 +1,687 @@
+// Copyright (c) 2024 Sumner Evans
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package verificationhelper_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"maunium.net/go/mautrix"
+	"maunium.net/go/mautrix/crypto"
+	"maunium.net/go/mautrix/crypto/cryptohelper"
+	"maunium.net/go/mautrix/crypto/verificationhelper"
+	"maunium.net/go/mautrix/event"
+	"maunium.net/go/mautrix/id"
+)
+
+var userID = id.UserID("@alice:example.org")
+var sendingDeviceID = id.DeviceID("sending")
+var receivingDeviceID = id.DeviceID("receiving")
+
+func init() {
+	log.Logger = zerolog.New(zerolog.ConsoleWriter{Out: os.Stdout, TimeFormat: time.RFC3339}).With().Timestamp().Logger().Level(zerolog.TraceLevel)
+	zerolog.DefaultContextLogger = &log.Logger
+}
+
+func initServerAndLogin(t *testing.T, ctx context.Context) (ts *mockServer, sendingClient, receivingClient *mautrix.Client, sendingCryptoStore, receivingCryptoStore crypto.Store, sendingMachine, receivingMachine *crypto.OlmMachine) {
+	t.Helper()
+	ts = createMockServer(t)
+
+	sendingClient, sendingCryptoStore = ts.Login(t, ctx, userID, sendingDeviceID)
+	sendingMachine = sendingClient.Crypto.(*cryptohelper.CryptoHelper).Machine()
+	receivingClient, receivingCryptoStore = ts.Login(t, ctx, userID, receivingDeviceID)
+	receivingMachine = receivingClient.Crypto.(*cryptohelper.CryptoHelper).Machine()
+
+	err := sendingCryptoStore.PutDevice(ctx, userID, sendingMachine.OwnIdentity())
+	require.NoError(t, err)
+	err = sendingCryptoStore.PutDevice(ctx, userID, receivingMachine.OwnIdentity())
+	require.NoError(t, err)
+	err = receivingCryptoStore.PutDevice(ctx, userID, sendingMachine.OwnIdentity())
+	require.NoError(t, err)
+	err = receivingCryptoStore.PutDevice(ctx, userID, receivingMachine.OwnIdentity())
+	require.NoError(t, err)
+	return
+}
+
+func initDefaultCallbacks(t *testing.T, ctx context.Context, sendingClient, receivingClient *mautrix.Client, sendingMachine, receivingMachine *crypto.OlmMachine) (sendingCallbacks, receivingCallbacks *allVerificationCallbacks, sendingHelper, receivingHelper *verificationhelper.VerificationHelper) {
+	t.Helper()
+	sendingCallbacks = newAllVerificationCallbacks()
+	sendingHelper = verificationhelper.NewVerificationHelper(sendingClient, sendingMachine, sendingCallbacks, true)
+	require.NoError(t, sendingHelper.Init(ctx))
+
+	receivingCallbacks = newAllVerificationCallbacks()
+	receivingHelper = verificationhelper.NewVerificationHelper(receivingClient, receivingMachine, receivingCallbacks, true)
+	require.NoError(t, receivingHelper.Init(ctx))
+	return
+}
+
+func TestSelfVerification_Start(t *testing.T) {
+	ctx := log.Logger.WithContext(context.TODO())
+	receivingDeviceID2 := id.DeviceID("receiving2")
+
+	testCases := []struct {
+		supportsScan                bool
+		callbacks                   MockVerificationCallbacks
+		startVerificationErrMsg     string
+		expectedVerificationMethods []event.VerificationMethod
+	}{
+		{false, newBaseVerificationCallbacks(), "no supported verification methods", nil},
+		{true, newBaseVerificationCallbacks(), "", []event.VerificationMethod{event.VerificationMethodQRCodeScan, event.VerificationMethodReciprocate}},
+		{false, newSASVerificationCallbacks(), "", []event.VerificationMethod{event.VerificationMethodSAS}},
+		{true, newSASVerificationCallbacks(), "", []event.VerificationMethod{event.VerificationMethodQRCodeScan, event.VerificationMethodReciprocate, event.VerificationMethodSAS}},
+		{true, newQRCodeVerificationCallbacks(), "", []event.VerificationMethod{event.VerificationMethodQRCodeScan, event.VerificationMethodQRCodeShow, event.VerificationMethodReciprocate}},
+		{false, newQRCodeVerificationCallbacks(), "", []event.VerificationMethod{event.VerificationMethodQRCodeShow, event.VerificationMethodReciprocate}},
+		{false, newAllVerificationCallbacks(), "", []event.VerificationMethod{event.VerificationMethodQRCodeShow, event.VerificationMethodReciprocate, event.VerificationMethodSAS}},
+		{true, newAllVerificationCallbacks(), "", []event.VerificationMethod{event.VerificationMethodQRCodeScan, event.VerificationMethodQRCodeShow, event.VerificationMethodReciprocate, event.VerificationMethodSAS}},
+	}
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			ts := createMockServer(t)
+			defer ts.Close()
+
+			client, cryptoStore := ts.Login(t, ctx, userID, sendingDeviceID)
+			addDeviceID(ctx, cryptoStore, userID, sendingDeviceID)
+			addDeviceID(ctx, cryptoStore, userID, receivingDeviceID)
+			addDeviceID(ctx, cryptoStore, userID, receivingDeviceID2)
+
+			senderHelper := verificationhelper.NewVerificationHelper(client, client.Crypto.(*cryptohelper.CryptoHelper).Machine(), tc.callbacks, tc.supportsScan)
+			err := senderHelper.Init(ctx)
+			require.NoError(t, err)
+
+			txnID, err := senderHelper.StartVerification(ctx, userID)
+			if tc.startVerificationErrMsg != "" {
+				assert.ErrorContains(t, err, tc.startVerificationErrMsg)
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.NotEmpty(t, txnID)
+
+			toDeviceInbox := ts.DeviceInbox[userID]
+
+			// Ensure that we didn't send a verification request to the
+			// sending device.
+			assert.Empty(t, toDeviceInbox[sendingDeviceID])
+
+			// Ensure that the verification request was sent to both of
+			// the other devices.
+			assert.NotEmpty(t, toDeviceInbox[receivingDeviceID])
+			assert.NotEmpty(t, toDeviceInbox[receivingDeviceID2])
+			assert.Equal(t, toDeviceInbox[receivingDeviceID], toDeviceInbox[receivingDeviceID2])
+			assert.Len(t, toDeviceInbox[receivingDeviceID], 1)
+
+			// Ensure that the verification request is correct.
+			verificationRequest := toDeviceInbox[receivingDeviceID][0].Content.AsVerificationRequest()
+			assert.Equal(t, sendingDeviceID, verificationRequest.FromDevice)
+			assert.Equal(t, txnID, verificationRequest.TransactionID)
+			assert.ElementsMatch(t, tc.expectedVerificationMethods, verificationRequest.Methods)
+		})
+	}
+}
+
+func TestSelfVerification_Accept_NoSupportedMethods(t *testing.T) {
+	ctx := log.Logger.WithContext(context.TODO())
+
+	ts := createMockServer(t)
+	defer ts.Close()
+
+	sendingClient, sendingCryptoStore := ts.Login(t, ctx, userID, sendingDeviceID)
+	receivingClient, _ := ts.Login(t, ctx, userID, receivingDeviceID)
+	addDeviceID(ctx, sendingCryptoStore, userID, sendingDeviceID)
+	addDeviceID(ctx, sendingCryptoStore, userID, receivingDeviceID)
+
+	sendingMachine := sendingClient.Crypto.(*cryptohelper.CryptoHelper).Machine()
+	recoveryKey, cache, err := sendingMachine.GenerateAndUploadCrossSigningKeys(ctx, nil, "")
+	assert.NoError(t, err)
+	assert.NotEmpty(t, recoveryKey)
+	assert.NotNil(t, cache)
+
+	sendingHelper := verificationhelper.NewVerificationHelper(sendingClient, sendingMachine, newAllVerificationCallbacks(), true)
+	err = sendingHelper.Init(ctx)
+	require.NoError(t, err)
+
+	receivingCallbacks := newBaseVerificationCallbacks()
+	receivingHelper := verificationhelper.NewVerificationHelper(receivingClient, receivingClient.Crypto.(*cryptohelper.CryptoHelper).Machine(), receivingCallbacks, false)
+	err = receivingHelper.Init(ctx)
+	require.NoError(t, err)
+
+	txnID, err := sendingHelper.StartVerification(ctx, userID)
+	require.NoError(t, err)
+	require.NotEmpty(t, txnID)
+
+	ts.dispatchToDevice(t, ctx, receivingClient)
+
+	// Ensure that the receiver ignored the request because it
+	// doesn't support any of the verification methods in the
+	// request.
+	assert.Empty(t, receivingCallbacks.GetRequestedVerifications())
+}
+
+func TestSelfVerification_Accept_CorrectMethodsPresented(t *testing.T) {
+	ctx := log.Logger.WithContext(context.TODO())
+
+	testCases := []struct {
+		sendingSupportsScan         bool
+		receivingSupportsScan       bool
+		sendingCallbacks            MockVerificationCallbacks
+		receivingCallbacks          MockVerificationCallbacks
+		expectedVerificationMethods []event.VerificationMethod
+	}{
+		{false, false, newSASVerificationCallbacks(), newSASVerificationCallbacks(), []event.VerificationMethod{event.VerificationMethodSAS}},
+		{true, false, newQRCodeVerificationCallbacks(), newQRCodeVerificationCallbacks(), []event.VerificationMethod{event.VerificationMethodQRCodeShow, event.VerificationMethodReciprocate}},
+		{false, true, newQRCodeVerificationCallbacks(), newQRCodeVerificationCallbacks(), []event.VerificationMethod{event.VerificationMethodQRCodeScan, event.VerificationMethodReciprocate}},
+		{true, false, newAllVerificationCallbacks(), newAllVerificationCallbacks(), []event.VerificationMethod{event.VerificationMethodQRCodeShow, event.VerificationMethodReciprocate, event.VerificationMethodSAS}},
+		{true, true, newAllVerificationCallbacks(), newAllVerificationCallbacks(), []event.VerificationMethod{event.VerificationMethodQRCodeShow, event.VerificationMethodQRCodeScan, event.VerificationMethodReciprocate, event.VerificationMethodSAS}},
+	}
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			ts, sendingClient, receivingClient, _, _, sendingMachine, receivingMachine := initServerAndLogin(t, ctx)
+			defer ts.Close()
+
+			recoveryKey, sendingCrossSigningKeysCache, err := sendingMachine.GenerateAndUploadCrossSigningKeys(ctx, nil, "")
+			assert.NoError(t, err)
+			assert.NotEmpty(t, recoveryKey)
+			assert.NotNil(t, sendingCrossSigningKeysCache)
+
+			sendingHelper := verificationhelper.NewVerificationHelper(sendingClient, sendingMachine, tc.sendingCallbacks, tc.sendingSupportsScan)
+			err = sendingHelper.Init(ctx)
+			require.NoError(t, err)
+
+			receivingHelper := verificationhelper.NewVerificationHelper(receivingClient, receivingMachine, tc.receivingCallbacks, tc.receivingSupportsScan)
+			err = receivingHelper.Init(ctx)
+			require.NoError(t, err)
+
+			txnID, err := sendingHelper.StartVerification(ctx, userID)
+			require.NoError(t, err)
+
+			// Process the verification request on the receiving device.
+			ts.dispatchToDevice(t, ctx, receivingClient)
+
+			// Ensure that the receiving device received a verification
+			// request with the correct transaction ID.
+			assert.ElementsMatch(t, []id.VerificationTransactionID{txnID}, tc.receivingCallbacks.GetRequestedVerifications()[userID])
+
+			// Have the receiving device accept the verification request.
+			err = receivingHelper.AcceptVerification(ctx, txnID)
+			require.NoError(t, err)
+
+			_, sendingIsQRCallbacks := tc.sendingCallbacks.(*qrCodeVerificationCallbacks)
+			_, sendingIsAllCallbacks := tc.sendingCallbacks.(*allVerificationCallbacks)
+			sendingCanShowQR := sendingIsQRCallbacks || sendingIsAllCallbacks
+			_, receivingIsQRCallbacks := tc.receivingCallbacks.(*qrCodeVerificationCallbacks)
+			_, receivingIsAllCallbacks := tc.receivingCallbacks.(*allVerificationCallbacks)
+			receivingCanShowQR := receivingIsQRCallbacks || receivingIsAllCallbacks
+
+			// Ensure that if the receiving device should show a QR code that
+			// it has the correct content.
+			if tc.sendingSupportsScan && receivingCanShowQR {
+				receivingShownQRCode := tc.receivingCallbacks.GetQRCodeShown(txnID)
+				require.NotNil(t, receivingShownQRCode)
+				assert.Equal(t, txnID, receivingShownQRCode.TransactionID)
+				assert.NotEmpty(t, receivingShownQRCode.SharedSecret)
+			}
+
+			// Check for whether the receiving device should be scanning a QR
+			// code.
+			if tc.receivingSupportsScan && sendingCanShowQR {
+				assert.Contains(t, tc.receivingCallbacks.GetScanQRCodeTransactions(), txnID)
+			}
+
+			// Check that the m.key.verification.ready event has the correct
+			// content.
+			sendingInbox := ts.DeviceInbox[userID][sendingDeviceID]
+			assert.Len(t, sendingInbox, 1)
+			readyEvt := sendingInbox[0].Content.AsVerificationReady()
+			assert.Equal(t, txnID, readyEvt.TransactionID)
+			assert.Equal(t, receivingDeviceID, readyEvt.FromDevice)
+			assert.ElementsMatch(t, tc.expectedVerificationMethods, readyEvt.Methods)
+
+			// Receive the m.key.verification.ready event on the sending
+			// device.
+			ts.dispatchToDevice(t, ctx, sendingClient)
+
+			// Ensure that if the sending device should show a QR code that it
+			// has the correct content.
+			if tc.receivingSupportsScan && sendingCanShowQR {
+				sendingShownQRCode := tc.sendingCallbacks.GetQRCodeShown(txnID)
+				require.NotNil(t, sendingShownQRCode)
+				assert.Equal(t, txnID, sendingShownQRCode.TransactionID)
+				assert.NotEmpty(t, sendingShownQRCode.SharedSecret)
+			}
+
+			// Check for whether the sending device should be scanning a QR
+			// code.
+			if tc.sendingSupportsScan && receivingCanShowQR {
+				assert.Contains(t, tc.sendingCallbacks.GetScanQRCodeTransactions(), txnID)
+			}
+		})
+	}
+}
+
+func TestSelfVerification_Accept_QRContents(t *testing.T) {
+	ctx := log.Logger.WithContext(context.TODO())
+
+	testCases := []struct {
+		sendingGeneratedCrossSigningKeys   bool
+		receivingGeneratedCrossSigningKeys bool
+		expectedAcceptError                string
+	}{
+		{true, false, ""},
+		{false, true, ""},
+		{false, false, "failed to get own cross-signing master public key"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("sendingGenerated=%t receivingGenerated=%t err=%s", tc.sendingGeneratedCrossSigningKeys, tc.receivingGeneratedCrossSigningKeys, tc.expectedAcceptError), func(t *testing.T) {
+			ts, sendingClient, receivingClient, _, _, sendingMachine, receivingMachine := initServerAndLogin(t, ctx)
+			defer ts.Close()
+			sendingCallbacks, receivingCallbacks, sendingHelper, receivingHelper := initDefaultCallbacks(t, ctx, sendingClient, receivingClient, sendingMachine, receivingMachine)
+			var err error
+
+			var sendingRecoveryKey, receivingRecoveryKey string
+			var sendingCrossSigningKeysCache, receivingCrossSigningKeysCache *crypto.CrossSigningKeysCache
+
+			if tc.sendingGeneratedCrossSigningKeys {
+				sendingRecoveryKey, sendingCrossSigningKeysCache, err = sendingMachine.GenerateAndUploadCrossSigningKeys(ctx, nil, "")
+				require.NoError(t, err)
+				assert.NotEmpty(t, sendingRecoveryKey)
+				assert.NotNil(t, sendingCrossSigningKeysCache)
+			}
+
+			if tc.receivingGeneratedCrossSigningKeys {
+				receivingRecoveryKey, receivingCrossSigningKeysCache, err = receivingMachine.GenerateAndUploadCrossSigningKeys(ctx, nil, "")
+				require.NoError(t, err)
+				assert.NotEmpty(t, receivingRecoveryKey)
+				assert.NotNil(t, receivingCrossSigningKeysCache)
+			}
+
+			// Send the verification request from the sender device and accept
+			// it on the receiving device and receive the verification ready
+			// event on the sending device.
+			txnID, err := sendingHelper.StartVerification(ctx, userID)
+			require.NoError(t, err)
+			ts.dispatchToDevice(t, ctx, receivingClient)
+
+			err = receivingHelper.AcceptVerification(ctx, txnID)
+			if tc.expectedAcceptError != "" {
+				assert.ErrorContains(t, err, tc.expectedAcceptError)
+				return
+			} else {
+				require.NoError(t, err)
+			}
+
+			ts.dispatchToDevice(t, ctx, sendingClient)
+
+			receivingShownQRCode := receivingCallbacks.GetQRCodeShown(txnID)
+			require.NotNil(t, receivingShownQRCode)
+			assert.NotEmpty(t, receivingShownQRCode.SharedSecret)
+			assert.Equal(t, txnID, receivingShownQRCode.TransactionID)
+
+			sendingShownQRCode := sendingCallbacks.GetQRCodeShown(txnID)
+			require.NotNil(t, sendingShownQRCode)
+			assert.NotEmpty(t, sendingShownQRCode.SharedSecret)
+			assert.Equal(t, txnID, sendingShownQRCode.TransactionID)
+
+			// See the spec for the QR Code format:
+			// https://spec.matrix.org/v1.10/client-server-api/#qr-code-format
+			if tc.receivingGeneratedCrossSigningKeys {
+				masterKeyBytes := receivingMachine.GetOwnCrossSigningPublicKeys(ctx).MasterKey.Bytes()
+
+				// The receiving device should have shown a QR Code with
+				// trusted mode
+				assert.Equal(t, verificationhelper.QRCodeModeSelfVerifyingMasterKeyTrusted, receivingShownQRCode.Mode)
+				assert.EqualValues(t, masterKeyBytes, receivingShownQRCode.Key1)                                  // master key
+				assert.EqualValues(t, sendingMachine.OwnIdentity().SigningKey.Bytes(), receivingShownQRCode.Key2) // other device key
+
+				// The sending device should have shown a QR code with
+				// untrusted mode.
+				assert.Equal(t, verificationhelper.QRCodeModeSelfVerifyingMasterKeyUntrusted, sendingShownQRCode.Mode)
+				assert.EqualValues(t, sendingMachine.OwnIdentity().SigningKey.Bytes(), sendingShownQRCode.Key1) // own device key
+				assert.EqualValues(t, masterKeyBytes, sendingShownQRCode.Key2)                                  // master key
+			} else if tc.sendingGeneratedCrossSigningKeys {
+				masterKeyBytes := sendingMachine.GetOwnCrossSigningPublicKeys(ctx).MasterKey.Bytes()
+
+				// The receiving device should have shown a QR code with
+				// untrusted mode
+				assert.Equal(t, verificationhelper.QRCodeModeSelfVerifyingMasterKeyUntrusted, receivingShownQRCode.Mode)
+				assert.EqualValues(t, receivingMachine.OwnIdentity().SigningKey.Bytes(), receivingShownQRCode.Key1) // own device key
+				assert.EqualValues(t, masterKeyBytes, receivingShownQRCode.Key2)                                    // master key
+
+				// The sending device should have shown a QR code with trusted
+				// mode.
+				assert.Equal(t, verificationhelper.QRCodeModeSelfVerifyingMasterKeyTrusted, sendingShownQRCode.Mode)
+				assert.EqualValues(t, masterKeyBytes, sendingShownQRCode.Key1)                                    // master key
+				assert.EqualValues(t, receivingMachine.OwnIdentity().SigningKey.Bytes(), sendingShownQRCode.Key2) // other device key
+			}
+		})
+	}
+}
+
+// TestAcceptSelfVerificationCancelOnNonParticipatingDevices ensures that we do
+// not regress https://github.com/mautrix/go/pull/230.
+func TestSelfVerification_Accept_CancelOnNonParticipatingDevices(t *testing.T) {
+	ctx := log.Logger.WithContext(context.TODO())
+	ts, sendingClient, receivingClient, sendingCryptoStore, receivingCryptoStore, sendingMachine, receivingMachine := initServerAndLogin(t, ctx)
+	defer ts.Close()
+	_, _, sendingHelper, receivingHelper := initDefaultCallbacks(t, ctx, sendingClient, receivingClient, sendingMachine, receivingMachine)
+
+	nonParticipatingDeviceID1 := id.DeviceID("non-participating1")
+	nonParticipatingDeviceID2 := id.DeviceID("non-participating2")
+	addDeviceID(ctx, sendingCryptoStore, userID, nonParticipatingDeviceID1)
+	addDeviceID(ctx, sendingCryptoStore, userID, nonParticipatingDeviceID2)
+	addDeviceID(ctx, receivingCryptoStore, userID, nonParticipatingDeviceID1)
+	addDeviceID(ctx, receivingCryptoStore, userID, nonParticipatingDeviceID2)
+
+	_, _, err := sendingMachine.GenerateAndUploadCrossSigningKeys(ctx, nil, "")
+	assert.NoError(t, err)
+
+	// Send the verification request from the sender device and accept it on
+	// the receiving device.
+	txnID, err := sendingHelper.StartVerification(ctx, userID)
+	require.NoError(t, err)
+	ts.dispatchToDevice(t, ctx, receivingClient)
+	err = receivingHelper.AcceptVerification(ctx, txnID)
+	require.NoError(t, err)
+
+	// Receive the m.key.verification.ready event on the sending device.
+	ts.dispatchToDevice(t, ctx, sendingClient)
+
+	// The sending and receiving devices should not have any cancellation
+	// events in their inboxes.
+	assert.Empty(t, ts.DeviceInbox[userID][sendingDeviceID])
+	assert.Empty(t, ts.DeviceInbox[userID][receivingDeviceID])
+
+	// There should now be cancellation events in the non-participating devices
+	// inboxes (in addition to the request event).
+	assert.Len(t, ts.DeviceInbox[userID][nonParticipatingDeviceID1], 2)
+	assert.Len(t, ts.DeviceInbox[userID][nonParticipatingDeviceID2], 2)
+	assert.Equal(t, ts.DeviceInbox[userID][nonParticipatingDeviceID1][1], ts.DeviceInbox[userID][nonParticipatingDeviceID2][1])
+	cancellationEvent := ts.DeviceInbox[userID][nonParticipatingDeviceID1][1].Content.AsVerificationCancel()
+	assert.Equal(t, txnID, cancellationEvent.TransactionID)
+	assert.Equal(t, event.VerificationCancelCodeAccepted, cancellationEvent.Code)
+}
+
+func TestSelfVerification_ScanQRAndConfirmScan(t *testing.T) {
+	ctx := log.Logger.WithContext(context.TODO())
+
+	testCases := []struct {
+		sendingGeneratedCrossSigningKeys bool
+		sendingScansQR                   bool // false indicates that receiving device should emulate a scan
+	}{
+		{false, false},
+		{false, true},
+		{true, false},
+		{true, true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("sendingGeneratedCrossSigningKeys=%t sendingScansQR=%t", tc.sendingGeneratedCrossSigningKeys, tc.sendingScansQR), func(t *testing.T) {
+			ts, sendingClient, receivingClient, _, _, sendingMachine, receivingMachine := initServerAndLogin(t, ctx)
+			defer ts.Close()
+			sendingCallbacks, receivingCallbacks, sendingHelper, receivingHelper := initDefaultCallbacks(t, ctx, sendingClient, receivingClient, sendingMachine, receivingMachine)
+			var err error
+
+			if tc.sendingGeneratedCrossSigningKeys {
+				_, _, err = sendingMachine.GenerateAndUploadCrossSigningKeys(ctx, nil, "")
+				require.NoError(t, err)
+			} else {
+				_, _, err = receivingMachine.GenerateAndUploadCrossSigningKeys(ctx, nil, "")
+				require.NoError(t, err)
+			}
+
+			// Send the verification request from the sender device and accept
+			// it on the receiving device and receive the verification ready
+			// event on the sending device.
+			txnID, err := sendingHelper.StartVerification(ctx, userID)
+			require.NoError(t, err)
+			ts.dispatchToDevice(t, ctx, receivingClient)
+			err = receivingHelper.AcceptVerification(ctx, txnID)
+			require.NoError(t, err)
+			ts.dispatchToDevice(t, ctx, sendingClient)
+
+			receivingShownQRCode := receivingCallbacks.GetQRCodeShown(txnID)
+			require.NotNil(t, receivingShownQRCode)
+			sendingShownQRCode := sendingCallbacks.GetQRCodeShown(txnID)
+			require.NotNil(t, sendingShownQRCode)
+
+			if tc.sendingScansQR {
+				// Emulate scanning the QR code shown by the receiving device
+				// on the sending device.
+				err := sendingHelper.HandleScannedQRData(ctx, receivingShownQRCode.Bytes())
+				require.NoError(t, err)
+
+				// Ensure that the receiving device received a verification
+				// start event and a verification done event.
+				receivingInbox := ts.DeviceInbox[userID][receivingDeviceID]
+				assert.Len(t, receivingInbox, 2)
+
+				startEvt := receivingInbox[0].Content.AsVerificationStart()
+				assert.Equal(t, txnID, startEvt.TransactionID)
+				assert.Equal(t, sendingDeviceID, startEvt.FromDevice)
+				assert.Equal(t, event.VerificationMethodReciprocate, startEvt.Method)
+				assert.EqualValues(t, receivingShownQRCode.SharedSecret, startEvt.Secret)
+
+				doneEvt := receivingInbox[1].Content.AsVerificationDone()
+				assert.Equal(t, txnID, doneEvt.TransactionID)
+
+				// Handle the start and done events on the receiving client and
+				// confirm the scan.
+				ts.dispatchToDevice(t, ctx, receivingClient)
+
+				// Ensure that the receiving device detected that its QR code
+				// was scanned.
+				assert.True(t, receivingCallbacks.WasOurQRCodeScanned(txnID))
+				err = receivingHelper.ConfirmQRCodeScanned(ctx, txnID)
+				require.NoError(t, err)
+
+				// Ensure that the sending device received a verification done
+				// event.
+				sendingInbox := ts.DeviceInbox[userID][sendingDeviceID]
+				require.Len(t, sendingInbox, 1)
+				doneEvt = sendingInbox[0].Content.AsVerificationDone()
+				assert.Equal(t, txnID, doneEvt.TransactionID)
+
+				ts.dispatchToDevice(t, ctx, sendingClient)
+			} else { // receiving scans QR
+				// Emulate scanning the QR code shown by the sending device on
+				// the receiving device.
+				err := receivingHelper.HandleScannedQRData(ctx, sendingShownQRCode.Bytes())
+				require.NoError(t, err)
+
+				// Ensure that the sending device received a verification
+				// start event and a verification done event.
+				sendingInbox := ts.DeviceInbox[userID][sendingDeviceID]
+				assert.Len(t, sendingInbox, 2)
+
+				startEvt := sendingInbox[0].Content.AsVerificationStart()
+				assert.Equal(t, txnID, startEvt.TransactionID)
+				assert.Equal(t, receivingDeviceID, startEvt.FromDevice)
+				assert.Equal(t, event.VerificationMethodReciprocate, startEvt.Method)
+				assert.EqualValues(t, sendingShownQRCode.SharedSecret, startEvt.Secret)
+
+				doneEvt := sendingInbox[1].Content.AsVerificationDone()
+				assert.Equal(t, txnID, doneEvt.TransactionID)
+
+				// Handle the start and done events on the receiving client and
+				// confirm the scan.
+				ts.dispatchToDevice(t, ctx, sendingClient)
+
+				// Ensure that the sending device detected that its QR code was
+				// scanned.
+				assert.True(t, sendingCallbacks.WasOurQRCodeScanned(txnID))
+				err = sendingHelper.ConfirmQRCodeScanned(ctx, txnID)
+				require.NoError(t, err)
+
+				// Ensure that the receiving device received a verification
+				// done event.
+				receivingInbox := ts.DeviceInbox[userID][receivingDeviceID]
+				require.Len(t, receivingInbox, 1)
+				doneEvt = receivingInbox[0].Content.AsVerificationDone()
+				assert.Equal(t, txnID, doneEvt.TransactionID)
+
+				ts.dispatchToDevice(t, ctx, receivingClient)
+			}
+
+			// Ensure that both devices have marked the verification as done.
+			assert.True(t, sendingCallbacks.IsVerificationDone(txnID))
+			assert.True(t, receivingCallbacks.IsVerificationDone(txnID))
+		})
+	}
+}
+
+func TestSelfVerification_ErrorOnDoubleAccept(t *testing.T) {
+	ctx := log.Logger.WithContext(context.TODO())
+	ts, sendingClient, receivingClient, _, _, sendingMachine, receivingMachine := initServerAndLogin(t, ctx)
+	defer ts.Close()
+	_, _, sendingHelper, receivingHelper := initDefaultCallbacks(t, ctx, sendingClient, receivingClient, sendingMachine, receivingMachine)
+
+	_, _, err := sendingMachine.GenerateAndUploadCrossSigningKeys(ctx, nil, "")
+	require.NoError(t, err)
+
+	txnID, err := sendingHelper.StartVerification(ctx, userID)
+	require.NoError(t, err)
+	ts.dispatchToDevice(t, ctx, receivingClient)
+	err = receivingHelper.AcceptVerification(ctx, txnID)
+	require.NoError(t, err)
+	err = receivingHelper.AcceptVerification(ctx, txnID)
+	require.ErrorContains(t, err, "transaction is not in the requested state")
+}
+
+func TestSelfVerification_ScanQRTransactionIDCorrupted(t *testing.T) {
+	ctx := log.Logger.WithContext(context.TODO())
+
+	ts, sendingClient, receivingClient, _, _, sendingMachine, receivingMachine := initServerAndLogin(t, ctx)
+	defer ts.Close()
+	sendingCallbacks, receivingCallbacks, sendingHelper, receivingHelper := initDefaultCallbacks(t, ctx, sendingClient, receivingClient, sendingMachine, receivingMachine)
+	var err error
+
+	_, _, err = sendingMachine.GenerateAndUploadCrossSigningKeys(ctx, nil, "")
+	require.NoError(t, err)
+
+	// Send the verification request from the sender device and accept
+	// it on the receiving device and receive the verification ready
+	// event on the sending device.
+	txnID, err := sendingHelper.StartVerification(ctx, userID)
+	require.NoError(t, err)
+	ts.dispatchToDevice(t, ctx, receivingClient)
+	err = receivingHelper.AcceptVerification(ctx, txnID)
+	require.NoError(t, err)
+	ts.dispatchToDevice(t, ctx, sendingClient)
+
+	receivingShownQRCodeBytes := receivingCallbacks.GetQRCodeShown(txnID).Bytes()
+	sendingShownQRCodeBytes := sendingCallbacks.GetQRCodeShown(txnID).Bytes()
+
+	// Corrupt the QR codes (the 20th byte should be in the transaction ID)
+	receivingShownQRCodeBytes[20]++
+	sendingShownQRCodeBytes[20]++
+
+	// Emulate scanning the QR code shown by the receiving device
+	// on the sending device.
+	err = sendingHelper.HandleScannedQRData(ctx, receivingShownQRCodeBytes)
+	assert.ErrorContains(t, err, "unknown transaction ID found in QR code")
+
+	// Emulate scanning the QR code shown by the sending device on
+	// the receiving device.
+	err = receivingHelper.HandleScannedQRData(ctx, sendingShownQRCodeBytes)
+	assert.ErrorContains(t, err, "unknown transaction ID found in QR code")
+}
+
+func TestSelfVerification_ScanQRKeyCorrupted(t *testing.T) {
+	ctx := log.Logger.WithContext(context.TODO())
+
+	testCases := []struct {
+		sendingGeneratedCrossSigningKeys bool
+		sendingScansQR                   bool // false indicates that receiving device should emulate a scan
+		corruptByte                      int
+		expectedError                    string
+	}{
+		// The 50th byte should be in the first key
+		{false, false, 50, "the other device's key is not what we expected"}, // receiver scans sender QR code, sender doesn't trust the master key => mode 0x02 => key1 == sender device key
+		{false, true, 50, "the master key does not match"},                   // sender scans receiver QR code, receiver trusts the master key => mode 0x01 => key1 == master key
+		{true, false, 50, "the master key does not match"},                   // receiver scans sender QR code, sender trusts the master key => mode 0x01 => key1 == master key
+		{true, true, 50, "the other device's key is not what we expected"},   // sender scans receiver QR Code, receiver doesn't trust the master key => mode 0x02 => key1 == receiver device key
+		// The 100th byte should be in the second key
+		{false, false, 100, "the master key does not match"},                     // receiver scans sender QR code, sender doesn't trust the master key => mode 0x02 => key2 == master key
+		{false, true, 100, "the other device has the wrong key for this device"}, // sender scans receiver QR code, receiver trusts the master key => mode 0x01 => key2 == sender device key
+		{true, false, 100, "the other device has the wrong key for this device"}, // receiver scans sender QR code, sender trusts the master key => mode 0x01 => key2 == receiver device key
+		{true, true, 100, "the master key does not match"},                       // sender scans receiver QR Code, receiver doesn't trust the master key => mode 0x02 => key2 == master key
+	}
+
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("sendingGeneratedCrossSigningKeys=%t sendingScansQR=%t corrupt=%d", tc.sendingGeneratedCrossSigningKeys, tc.sendingScansQR, tc.corruptByte), func(t *testing.T) {
+			ts, sendingClient, receivingClient, _, _, sendingMachine, receivingMachine := initServerAndLogin(t, ctx)
+			defer ts.Close()
+			sendingCallbacks, receivingCallbacks, sendingHelper, receivingHelper := initDefaultCallbacks(t, ctx, sendingClient, receivingClient, sendingMachine, receivingMachine)
+			var err error
+
+			if tc.sendingGeneratedCrossSigningKeys {
+				_, _, err = sendingMachine.GenerateAndUploadCrossSigningKeys(ctx, nil, "")
+				require.NoError(t, err)
+			} else {
+				_, _, err = receivingMachine.GenerateAndUploadCrossSigningKeys(ctx, nil, "")
+				require.NoError(t, err)
+			}
+
+			// Send the verification request from the sender device and accept
+			// it on the receiving device and receive the verification ready
+			// event on the sending device.
+			txnID, err := sendingHelper.StartVerification(ctx, userID)
+			require.NoError(t, err)
+			ts.dispatchToDevice(t, ctx, receivingClient)
+			err = receivingHelper.AcceptVerification(ctx, txnID)
+			require.NoError(t, err)
+			ts.dispatchToDevice(t, ctx, sendingClient)
+
+			receivingShownQRCodeBytes := receivingCallbacks.GetQRCodeShown(txnID).Bytes()
+			sendingShownQRCodeBytes := sendingCallbacks.GetQRCodeShown(txnID).Bytes()
+
+			// Corrupt the QR codes
+			receivingShownQRCodeBytes[tc.corruptByte]++
+			sendingShownQRCodeBytes[tc.corruptByte]++
+
+			if tc.sendingScansQR {
+				// Emulate scanning the QR code shown by the receiving device
+				// on the sending device.
+				err := sendingHelper.HandleScannedQRData(ctx, receivingShownQRCodeBytes)
+				assert.ErrorContains(t, err, tc.expectedError)
+
+				// Ensure that the receiving device received a cancellation.
+				receivingInbox := ts.DeviceInbox[userID][receivingDeviceID]
+				assert.Len(t, receivingInbox, 1)
+				ts.dispatchToDevice(t, ctx, receivingClient)
+				cancellation := receivingCallbacks.GetVerificationCancellation(txnID)
+				require.NotNil(t, cancellation)
+				assert.Equal(t, event.VerificationCancelCodeKeyMismatch, cancellation.Code)
+				assert.Equal(t, tc.expectedError, cancellation.Reason)
+			} else { // receiving scans QR
+				// Emulate scanning the QR code shown by the sending device on
+				// the receiving device.
+				err := receivingHelper.HandleScannedQRData(ctx, sendingShownQRCodeBytes)
+				assert.ErrorContains(t, err, tc.expectedError)
+
+				// Ensure that the sending device received a cancellation.
+				sendingInbox := ts.DeviceInbox[userID][sendingDeviceID]
+				assert.Len(t, sendingInbox, 1)
+				ts.dispatchToDevice(t, ctx, sendingClient)
+				cancellation := sendingCallbacks.GetVerificationCancellation(txnID)
+				require.NotNil(t, cancellation)
+				assert.Equal(t, event.VerificationCancelCodeKeyMismatch, cancellation.Code)
+				assert.Equal(t, tc.expectedError, cancellation.Reason)
+			}
+		})
+	}
+}

--- a/event/verification.go
+++ b/event/verification.go
@@ -220,6 +220,10 @@ const (
 	VerificationCancelCodeAccepted           VerificationCancelCode = "m.accepted"
 	VerificationCancelCodeSASMismatch        VerificationCancelCode = "m.mismatched_sas"
 	VerificationCancelCodeCommitmentMismatch VerificationCancelCode = "m.mismatched_commitment"
+
+	// Non-spec codes
+	VerificationCancelCodeInternalError       VerificationCancelCode = "com.beeper.internal_error"
+	VerificationCancelCodeMasterKeyNotTrusted VerificationCancelCode = "com.beeper.master_key_not_trusted" // the master key is not trusted by this device, but the QR code that was scanned was from a device that doesn't trust the master key
 )
 
 // VerificationCancelEventContent represents the content of an


### PR DESCRIPTION
This PR adds end-to-end tests for the verificationhelper module. In the future, we might want to extract some of the test code such as the mock server into a separate test module if we need to E2E test anything else.

The E2E tests primarily test the happy-path, but there are some tests for the error cases as well. There are many happy paths because there are many different device combinations (scanning device vs scanned device, trust/doesn't trust the master key, etc.). I've tried to exhaustively test the happy paths.

This PR also fixes some verification bugs. Namely, it makes it so that the signing key is used in the QR code that gets generated instead of the identity key. This lines up with [what the Rust SDK does](https://github.com/matrix-org/matrix-rust-sdk/blob/1dc370942b641437a885ebacad81340e2e0d7239/crates/matrix-sdk-crypto/src/verification/qrcode.rs#L621).

I asked in [#e2e:matrix.org](https://matrix.to/#/#e2e:matrix.org) and @uhoreg responded:

> It should be the ed25519 key.  There was probably a bit of a terminology mixup in the MSC.  But all verification methods verify the ed25519 key.  In theory, devices should be able to change their curve25519 key, as long as the ed25519 key stays the same, though I don't think anyone has ever actually tried that, and I don't know what would happen if someone did. (I suspect that we would see lots of exciting errors)

It was not clear from the spec, so I'll probably create a spec clarification PR at some point to make it not so confusing to implement in the future.