### PR TITLE
verificationhelper: add tests and implement cross-signing

### DIFF
--- a/crypto/cross_sign_key.go
+++ b/crypto/cross_sign_key.go
@@ -142,6 +142,16 @@ func (mach *OlmMachine) PublishCrossSigningKeys(ctx context.Context, keys *Cross
 		return err
 	}
 
+	if err := mach.CryptoStore.PutSignature(ctx, userID, keys.MasterKey.PublicKey(), userID, mach.account.SigningKey(), masterSig); err != nil {
+		return fmt.Errorf("error storing signature of master key by device signing key in crypto store: %w", err)
+	}
+	if err := mach.CryptoStore.PutSignature(ctx, userID, keys.SelfSigningKey.PublicKey(), userID, keys.MasterKey.PublicKey(), selfSig); err != nil {
+		return fmt.Errorf("error storing signature of self-signing key by master key in crypto store: %w", err)
+	}
+	if err := mach.CryptoStore.PutSignature(ctx, userID, keys.UserSigningKey.PublicKey(), userID, keys.MasterKey.PublicKey(), userSig); err != nil {
+		return fmt.Errorf("error storing signature of user-signing key by master key in crypto store: %w", err)
+	}
+
 	mach.CrossSigningKeys = keys
 	mach.crossSigningPubkeys = keys.PublicKeys()
 

--- a/crypto/cross_sign_ssss.go
+++ b/crypto/cross_sign_ssss.go
@@ -100,12 +100,6 @@ func (mach *OlmMachine) GenerateAndUploadCrossSigningKeys(ctx context.Context, u
 		return "", nil, fmt.Errorf("failed to publish cross-signing keys: %w", err)
 	}
 
-	// Trust the master key
-	err = mach.SignOwnMasterKey(ctx)
-	if err != nil {
-		return "", nil, fmt.Errorf("failed to sign own master key: %w", err)
-	}
-
 	err = mach.SSSS.SetDefaultKeyID(ctx, key.ID)
 	if err != nil {
 		return "", nil, fmt.Errorf("failed to mark %s as the default key: %w", key.ID, err)

--- a/crypto/verificationhelper/callbacks_test.go
+++ b/crypto/verificationhelper/callbacks_test.go
@@ -27,6 +27,8 @@ type baseVerificationCallbacks struct {
 	qrCodesScanned           map[id.VerificationTransactionID]struct{}
 	doneTransactions         map[id.VerificationTransactionID]struct{}
 	verificationCancellation map[id.VerificationTransactionID]*event.VerificationCancelEventContent
+	emojisShown              map[id.VerificationTransactionID][]rune
+	decimalsShown            map[id.VerificationTransactionID][]int
 }
 
 func newBaseVerificationCallbacks() *baseVerificationCallbacks {
@@ -36,6 +38,8 @@ func newBaseVerificationCallbacks() *baseVerificationCallbacks {
 		qrCodesScanned:           map[id.VerificationTransactionID]struct{}{},
 		doneTransactions:         map[id.VerificationTransactionID]struct{}{},
 		verificationCancellation: map[id.VerificationTransactionID]*event.VerificationCancelEventContent{},
+		emojisShown:              map[id.VerificationTransactionID][]rune{},
+		decimalsShown:            map[id.VerificationTransactionID][]int{},
 	}
 }
 
@@ -65,6 +69,14 @@ func (c *baseVerificationCallbacks) GetVerificationCancellation(txnID id.Verific
 	return c.verificationCancellation[txnID]
 }
 
+func (c *baseVerificationCallbacks) GetEmojisShown(txnID id.VerificationTransactionID) []rune {
+	return c.emojisShown[txnID]
+}
+
+func (c *baseVerificationCallbacks) GetDecimalsShown(txnID id.VerificationTransactionID) []int {
+	return c.decimalsShown[txnID]
+}
+
 func (c *baseVerificationCallbacks) VerificationRequested(ctx context.Context, txnID id.VerificationTransactionID, from id.UserID) {
 	c.verificationsRequested[from] = append(c.verificationsRequested[from], txnID)
 }
@@ -92,8 +104,9 @@ func newSASVerificationCallbacksWithBase(base *baseVerificationCallbacks) *sasVe
 	return &sasVerificationCallbacks{base}
 }
 
-func (*sasVerificationCallbacks) ShowSAS(ctx context.Context, txnID id.VerificationTransactionID, emojis []rune, decimals []int) {
-	panic("show sas")
+func (c *sasVerificationCallbacks) ShowSAS(ctx context.Context, txnID id.VerificationTransactionID, emojis []rune, decimals []int) {
+	c.emojisShown[txnID] = emojis
+	c.decimalsShown[txnID] = decimals
 }
 
 type qrCodeVerificationCallbacks struct {

--- a/crypto/verificationhelper/mockserver_test.go
+++ b/crypto/verificationhelper/mockserver_test.go
@@ -17,6 +17,7 @@ import (
 	"testing"
 
 	"github.com/gorilla/mux"
+	"github.com/rs/zerolog/log"
 	"github.com/stretchr/testify/require"
 	"go.mau.fi/util/random"
 
@@ -221,6 +222,12 @@ func (ms *mockServer) Login(t *testing.T, ctx context.Context, userID id.UserID,
 
 	err = cryptoHelper.Init(ctx)
 	require.NoError(t, err)
+
+	machineLog := log.Logger.With().
+		Stringer("my_user_id", userID).
+		Stringer("my_device_id", deviceID).
+		Logger()
+	cryptoHelper.Machine().Log = &machineLog
 
 	err = cryptoHelper.Machine().ShareKeys(ctx, 50)
 	require.NoError(t, err)

--- a/crypto/verificationhelper/verificationhelper_qr_crosssign_test.go
+++ b/crypto/verificationhelper/verificationhelper_qr_crosssign_test.go
@@ -1,0 +1,154 @@
+// Copyright (c) 2024 Sumner Evans
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package verificationhelper_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/rs/zerolog/log"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"maunium.net/go/mautrix/event"
+	"maunium.net/go/mautrix/id"
+)
+
+func TestCrossSignVerification_ScanQRAndConfirmScan(t *testing.T) {
+	ctx := log.Logger.WithContext(context.TODO())
+
+	testCases := []struct {
+		sendingScansQR bool // false indicates that receiving device should emulate a scan
+	}{
+		{false},
+		{true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("sendingScansQR=%t", tc.sendingScansQR), func(t *testing.T) {
+			ts, sendingClient, receivingClient, _, _, sendingMachine, receivingMachine := initServerAndLoginAliceBob(t, ctx)
+			defer ts.Close()
+			sendingCallbacks, receivingCallbacks, sendingHelper, receivingHelper := initDefaultCallbacks(t, ctx, sendingClient, receivingClient, sendingMachine, receivingMachine)
+			var err error
+
+			// Generate cross-signing keys for both users
+			_, _, err = sendingMachine.GenerateAndUploadCrossSigningKeys(ctx, nil, "")
+			require.NoError(t, err)
+			_, _, err = receivingMachine.GenerateAndUploadCrossSigningKeys(ctx, nil, "")
+			require.NoError(t, err)
+
+			// Fetch each other's keys
+			sendingMachine.FetchKeys(ctx, []id.UserID{bobUserID}, true)
+			receivingMachine.FetchKeys(ctx, []id.UserID{aliceUserID}, true)
+
+			// Send the verification request from the sender device and accept
+			// it on the receiving device and receive the verification ready
+			// event on the sending device.
+			txnID, err := sendingHelper.StartVerification(ctx, bobUserID)
+			require.NoError(t, err)
+			ts.dispatchToDevice(t, ctx, receivingClient)
+			err = receivingHelper.AcceptVerification(ctx, txnID)
+			require.NoError(t, err)
+			ts.dispatchToDevice(t, ctx, sendingClient)
+
+			receivingShownQRCode := receivingCallbacks.GetQRCodeShown(txnID)
+			require.NotNil(t, receivingShownQRCode)
+			sendingShownQRCode := sendingCallbacks.GetQRCodeShown(txnID)
+			require.NotNil(t, sendingShownQRCode)
+
+			if tc.sendingScansQR {
+				// Emulate scanning the QR code shown by the receiving device
+				// on the sending device.
+				err := sendingHelper.HandleScannedQRData(ctx, receivingShownQRCode.Bytes())
+				require.NoError(t, err)
+
+				// Ensure that the receiving device received a verification
+				// start event and a verification done event.
+				receivingInbox := ts.DeviceInbox[bobUserID][receivingDeviceID]
+				assert.Len(t, receivingInbox, 2)
+
+				startEvt := receivingInbox[0].Content.AsVerificationStart()
+				assert.Equal(t, txnID, startEvt.TransactionID)
+				assert.Equal(t, sendingDeviceID, startEvt.FromDevice)
+				assert.Equal(t, event.VerificationMethodReciprocate, startEvt.Method)
+				assert.EqualValues(t, receivingShownQRCode.SharedSecret, startEvt.Secret)
+
+				doneEvt := receivingInbox[1].Content.AsVerificationDone()
+				assert.Equal(t, txnID, doneEvt.TransactionID)
+
+				// Handle the start and done events on the receiving client and
+				// confirm the scan.
+				ts.dispatchToDevice(t, ctx, receivingClient)
+
+				// Ensure that the receiving device detected that its QR code
+				// was scanned.
+				assert.True(t, receivingCallbacks.WasOurQRCodeScanned(txnID))
+				err = receivingHelper.ConfirmQRCodeScanned(ctx, txnID)
+				require.NoError(t, err)
+
+				// Ensure that the sending device received a verification done
+				// event.
+				sendingInbox := ts.DeviceInbox[aliceUserID][sendingDeviceID]
+				require.Len(t, sendingInbox, 1)
+				doneEvt = sendingInbox[0].Content.AsVerificationDone()
+				assert.Equal(t, txnID, doneEvt.TransactionID)
+
+				ts.dispatchToDevice(t, ctx, sendingClient)
+			} else { // receiving scans QR
+				// Emulate scanning the QR code shown by the sending device on
+				// the receiving device.
+				err := receivingHelper.HandleScannedQRData(ctx, sendingShownQRCode.Bytes())
+				require.NoError(t, err)
+
+				// Ensure that the sending device received a verification
+				// start event and a verification done event.
+				sendingInbox := ts.DeviceInbox[aliceUserID][sendingDeviceID]
+				assert.Len(t, sendingInbox, 2)
+
+				startEvt := sendingInbox[0].Content.AsVerificationStart()
+				assert.Equal(t, txnID, startEvt.TransactionID)
+				assert.Equal(t, receivingDeviceID, startEvt.FromDevice)
+				assert.Equal(t, event.VerificationMethodReciprocate, startEvt.Method)
+				assert.EqualValues(t, sendingShownQRCode.SharedSecret, startEvt.Secret)
+
+				doneEvt := sendingInbox[1].Content.AsVerificationDone()
+				assert.Equal(t, txnID, doneEvt.TransactionID)
+
+				// Handle the start and done events on the receiving client and
+				// confirm the scan.
+				ts.dispatchToDevice(t, ctx, sendingClient)
+
+				// Ensure that the sending device detected that its QR code was
+				// scanned.
+				assert.True(t, sendingCallbacks.WasOurQRCodeScanned(txnID))
+				err = sendingHelper.ConfirmQRCodeScanned(ctx, txnID)
+				require.NoError(t, err)
+
+				// Ensure that the receiving device received a verification
+				// done event.
+				receivingInbox := ts.DeviceInbox[bobUserID][receivingDeviceID]
+				require.Len(t, receivingInbox, 1)
+				doneEvt = receivingInbox[0].Content.AsVerificationDone()
+				assert.Equal(t, txnID, doneEvt.TransactionID)
+
+				ts.dispatchToDevice(t, ctx, receivingClient)
+			}
+
+			// Ensure that both devices have marked the verification as done.
+			assert.True(t, sendingCallbacks.IsVerificationDone(txnID))
+			assert.True(t, receivingCallbacks.IsVerificationDone(txnID))
+
+			bobTrustsAlice, err := receivingMachine.IsUserTrusted(ctx, aliceUserID)
+			assert.NoError(t, err)
+			assert.True(t, bobTrustsAlice)
+			aliceTrustsBob, err := sendingMachine.IsUserTrusted(ctx, bobUserID)
+			assert.NoError(t, err)
+			assert.True(t, aliceTrustsBob)
+		})
+	}
+}

--- a/crypto/verificationhelper/verificationhelper_qr_self_test.go
+++ b/crypto/verificationhelper/verificationhelper_qr_self_test.go
@@ -35,7 +35,7 @@ func TestSelfVerification_Accept_QRContents(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(fmt.Sprintf("sendingGenerated=%t receivingGenerated=%t err=%s", tc.sendingGeneratedCrossSigningKeys, tc.receivingGeneratedCrossSigningKeys, tc.expectedAcceptError), func(t *testing.T) {
-			ts, sendingClient, receivingClient, _, _, sendingMachine, receivingMachine := initServerAndLogin(t, ctx)
+			ts, sendingClient, receivingClient, _, _, sendingMachine, receivingMachine := initServerAndLoginTwoAlice(t, ctx)
 			defer ts.Close()
 			sendingCallbacks, receivingCallbacks, sendingHelper, receivingHelper := initDefaultCallbacks(t, ctx, sendingClient, receivingClient, sendingMachine, receivingMachine)
 			var err error
@@ -134,7 +134,7 @@ func TestSelfVerification_ScanQRAndConfirmScan(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(fmt.Sprintf("sendingGeneratedCrossSigningKeys=%t sendingScansQR=%t", tc.sendingGeneratedCrossSigningKeys, tc.sendingScansQR), func(t *testing.T) {
-			ts, sendingClient, receivingClient, _, _, sendingMachine, receivingMachine := initServerAndLogin(t, ctx)
+			ts, sendingClient, receivingClient, _, _, sendingMachine, receivingMachine := initServerAndLoginTwoAlice(t, ctx)
 			defer ts.Close()
 			sendingCallbacks, receivingCallbacks, sendingHelper, receivingHelper := initDefaultCallbacks(t, ctx, sendingClient, receivingClient, sendingMachine, receivingMachine)
 			var err error
@@ -250,7 +250,7 @@ func TestSelfVerification_ScanQRAndConfirmScan(t *testing.T) {
 func TestSelfVerification_ScanQRTransactionIDCorrupted(t *testing.T) {
 	ctx := log.Logger.WithContext(context.TODO())
 
-	ts, sendingClient, receivingClient, _, _, sendingMachine, receivingMachine := initServerAndLogin(t, ctx)
+	ts, sendingClient, receivingClient, _, _, sendingMachine, receivingMachine := initServerAndLoginTwoAlice(t, ctx)
 	defer ts.Close()
 	sendingCallbacks, receivingCallbacks, sendingHelper, receivingHelper := initDefaultCallbacks(t, ctx, sendingClient, receivingClient, sendingMachine, receivingMachine)
 	var err error
@@ -309,7 +309,7 @@ func TestSelfVerification_ScanQRKeyCorrupted(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(fmt.Sprintf("sendingGeneratedCrossSigningKeys=%t sendingScansQR=%t corrupt=%d", tc.sendingGeneratedCrossSigningKeys, tc.sendingScansQR, tc.corruptByte), func(t *testing.T) {
-			ts, sendingClient, receivingClient, _, _, sendingMachine, receivingMachine := initServerAndLogin(t, ctx)
+			ts, sendingClient, receivingClient, _, _, sendingMachine, receivingMachine := initServerAndLoginTwoAlice(t, ctx)
 			defer ts.Close()
 			sendingCallbacks, receivingCallbacks, sendingHelper, receivingHelper := initDefaultCallbacks(t, ctx, sendingClient, receivingClient, sendingMachine, receivingMachine)
 			var err error

--- a/crypto/verificationhelper/verificationhelper_qr_test.go
+++ b/crypto/verificationhelper/verificationhelper_qr_test.go
@@ -9,268 +9,16 @@ package verificationhelper_test
 import (
 	"context"
 	"fmt"
-	"os"
 	"testing"
-	"time"
 
-	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"maunium.net/go/mautrix"
 	"maunium.net/go/mautrix/crypto"
-	"maunium.net/go/mautrix/crypto/cryptohelper"
 	"maunium.net/go/mautrix/crypto/verificationhelper"
 	"maunium.net/go/mautrix/event"
-	"maunium.net/go/mautrix/id"
 )
-
-var userID = id.UserID("@alice:example.org")
-var sendingDeviceID = id.DeviceID("sending")
-var receivingDeviceID = id.DeviceID("receiving")
-
-func init() {
-	log.Logger = zerolog.New(zerolog.ConsoleWriter{Out: os.Stdout, TimeFormat: time.RFC3339}).With().Timestamp().Logger().Level(zerolog.TraceLevel)
-	zerolog.DefaultContextLogger = &log.Logger
-}
-
-func initServerAndLogin(t *testing.T, ctx context.Context) (ts *mockServer, sendingClient, receivingClient *mautrix.Client, sendingCryptoStore, receivingCryptoStore crypto.Store, sendingMachine, receivingMachine *crypto.OlmMachine) {
-	t.Helper()
-	ts = createMockServer(t)
-
-	sendingClient, sendingCryptoStore = ts.Login(t, ctx, userID, sendingDeviceID)
-	sendingMachine = sendingClient.Crypto.(*cryptohelper.CryptoHelper).Machine()
-	receivingClient, receivingCryptoStore = ts.Login(t, ctx, userID, receivingDeviceID)
-	receivingMachine = receivingClient.Crypto.(*cryptohelper.CryptoHelper).Machine()
-
-	err := sendingCryptoStore.PutDevice(ctx, userID, sendingMachine.OwnIdentity())
-	require.NoError(t, err)
-	err = sendingCryptoStore.PutDevice(ctx, userID, receivingMachine.OwnIdentity())
-	require.NoError(t, err)
-	err = receivingCryptoStore.PutDevice(ctx, userID, sendingMachine.OwnIdentity())
-	require.NoError(t, err)
-	err = receivingCryptoStore.PutDevice(ctx, userID, receivingMachine.OwnIdentity())
-	require.NoError(t, err)
-	return
-}
-
-func initDefaultCallbacks(t *testing.T, ctx context.Context, sendingClient, receivingClient *mautrix.Client, sendingMachine, receivingMachine *crypto.OlmMachine) (sendingCallbacks, receivingCallbacks *allVerificationCallbacks, sendingHelper, receivingHelper *verificationhelper.VerificationHelper) {
-	t.Helper()
-	sendingCallbacks = newAllVerificationCallbacks()
-	sendingHelper = verificationhelper.NewVerificationHelper(sendingClient, sendingMachine, sendingCallbacks, true)
-	require.NoError(t, sendingHelper.Init(ctx))
-
-	receivingCallbacks = newAllVerificationCallbacks()
-	receivingHelper = verificationhelper.NewVerificationHelper(receivingClient, receivingMachine, receivingCallbacks, true)
-	require.NoError(t, receivingHelper.Init(ctx))
-	return
-}
-
-func TestSelfVerification_Start(t *testing.T) {
-	ctx := log.Logger.WithContext(context.TODO())
-	receivingDeviceID2 := id.DeviceID("receiving2")
-
-	testCases := []struct {
-		supportsScan                bool
-		callbacks                   MockVerificationCallbacks
-		startVerificationErrMsg     string
-		expectedVerificationMethods []event.VerificationMethod
-	}{
-		{false, newBaseVerificationCallbacks(), "no supported verification methods", nil},
-		{true, newBaseVerificationCallbacks(), "", []event.VerificationMethod{event.VerificationMethodQRCodeScan, event.VerificationMethodReciprocate}},
-		{false, newSASVerificationCallbacks(), "", []event.VerificationMethod{event.VerificationMethodSAS}},
-		{true, newSASVerificationCallbacks(), "", []event.VerificationMethod{event.VerificationMethodQRCodeScan, event.VerificationMethodReciprocate, event.VerificationMethodSAS}},
-		{true, newQRCodeVerificationCallbacks(), "", []event.VerificationMethod{event.VerificationMethodQRCodeScan, event.VerificationMethodQRCodeShow, event.VerificationMethodReciprocate}},
-		{false, newQRCodeVerificationCallbacks(), "", []event.VerificationMethod{event.VerificationMethodQRCodeShow, event.VerificationMethodReciprocate}},
-		{false, newAllVerificationCallbacks(), "", []event.VerificationMethod{event.VerificationMethodQRCodeShow, event.VerificationMethodReciprocate, event.VerificationMethodSAS}},
-		{true, newAllVerificationCallbacks(), "", []event.VerificationMethod{event.VerificationMethodQRCodeScan, event.VerificationMethodQRCodeShow, event.VerificationMethodReciprocate, event.VerificationMethodSAS}},
-	}
-
-	for i, tc := range testCases {
-		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
-			ts := createMockServer(t)
-			defer ts.Close()
-
-			client, cryptoStore := ts.Login(t, ctx, userID, sendingDeviceID)
-			addDeviceID(ctx, cryptoStore, userID, sendingDeviceID)
-			addDeviceID(ctx, cryptoStore, userID, receivingDeviceID)
-			addDeviceID(ctx, cryptoStore, userID, receivingDeviceID2)
-
-			senderHelper := verificationhelper.NewVerificationHelper(client, client.Crypto.(*cryptohelper.CryptoHelper).Machine(), tc.callbacks, tc.supportsScan)
-			err := senderHelper.Init(ctx)
-			require.NoError(t, err)
-
-			txnID, err := senderHelper.StartVerification(ctx, userID)
-			if tc.startVerificationErrMsg != "" {
-				assert.ErrorContains(t, err, tc.startVerificationErrMsg)
-				return
-			}
-
-			assert.NoError(t, err)
-			assert.NotEmpty(t, txnID)
-
-			toDeviceInbox := ts.DeviceInbox[userID]
-
-			// Ensure that we didn't send a verification request to the
-			// sending device.
-			assert.Empty(t, toDeviceInbox[sendingDeviceID])
-
-			// Ensure that the verification request was sent to both of
-			// the other devices.
-			assert.NotEmpty(t, toDeviceInbox[receivingDeviceID])
-			assert.NotEmpty(t, toDeviceInbox[receivingDeviceID2])
-			assert.Equal(t, toDeviceInbox[receivingDeviceID], toDeviceInbox[receivingDeviceID2])
-			assert.Len(t, toDeviceInbox[receivingDeviceID], 1)
-
-			// Ensure that the verification request is correct.
-			verificationRequest := toDeviceInbox[receivingDeviceID][0].Content.AsVerificationRequest()
-			assert.Equal(t, sendingDeviceID, verificationRequest.FromDevice)
-			assert.Equal(t, txnID, verificationRequest.TransactionID)
-			assert.ElementsMatch(t, tc.expectedVerificationMethods, verificationRequest.Methods)
-		})
-	}
-}
-
-func TestSelfVerification_Accept_NoSupportedMethods(t *testing.T) {
-	ctx := log.Logger.WithContext(context.TODO())
-
-	ts := createMockServer(t)
-	defer ts.Close()
-
-	sendingClient, sendingCryptoStore := ts.Login(t, ctx, userID, sendingDeviceID)
-	receivingClient, _ := ts.Login(t, ctx, userID, receivingDeviceID)
-	addDeviceID(ctx, sendingCryptoStore, userID, sendingDeviceID)
-	addDeviceID(ctx, sendingCryptoStore, userID, receivingDeviceID)
-
-	sendingMachine := sendingClient.Crypto.(*cryptohelper.CryptoHelper).Machine()
-	recoveryKey, cache, err := sendingMachine.GenerateAndUploadCrossSigningKeys(ctx, nil, "")
-	assert.NoError(t, err)
-	assert.NotEmpty(t, recoveryKey)
-	assert.NotNil(t, cache)
-
-	sendingHelper := verificationhelper.NewVerificationHelper(sendingClient, sendingMachine, newAllVerificationCallbacks(), true)
-	err = sendingHelper.Init(ctx)
-	require.NoError(t, err)
-
-	receivingCallbacks := newBaseVerificationCallbacks()
-	receivingHelper := verificationhelper.NewVerificationHelper(receivingClient, receivingClient.Crypto.(*cryptohelper.CryptoHelper).Machine(), receivingCallbacks, false)
-	err = receivingHelper.Init(ctx)
-	require.NoError(t, err)
-
-	txnID, err := sendingHelper.StartVerification(ctx, userID)
-	require.NoError(t, err)
-	require.NotEmpty(t, txnID)
-
-	ts.dispatchToDevice(t, ctx, receivingClient)
-
-	// Ensure that the receiver ignored the request because it
-	// doesn't support any of the verification methods in the
-	// request.
-	assert.Empty(t, receivingCallbacks.GetRequestedVerifications())
-}
-
-func TestSelfVerification_Accept_CorrectMethodsPresented(t *testing.T) {
-	ctx := log.Logger.WithContext(context.TODO())
-
-	testCases := []struct {
-		sendingSupportsScan         bool
-		receivingSupportsScan       bool
-		sendingCallbacks            MockVerificationCallbacks
-		receivingCallbacks          MockVerificationCallbacks
-		expectedVerificationMethods []event.VerificationMethod
-	}{
-		{false, false, newSASVerificationCallbacks(), newSASVerificationCallbacks(), []event.VerificationMethod{event.VerificationMethodSAS}},
-		{true, false, newQRCodeVerificationCallbacks(), newQRCodeVerificationCallbacks(), []event.VerificationMethod{event.VerificationMethodQRCodeShow, event.VerificationMethodReciprocate}},
-		{false, true, newQRCodeVerificationCallbacks(), newQRCodeVerificationCallbacks(), []event.VerificationMethod{event.VerificationMethodQRCodeScan, event.VerificationMethodReciprocate}},
-		{true, false, newAllVerificationCallbacks(), newAllVerificationCallbacks(), []event.VerificationMethod{event.VerificationMethodQRCodeShow, event.VerificationMethodReciprocate, event.VerificationMethodSAS}},
-		{true, true, newAllVerificationCallbacks(), newAllVerificationCallbacks(), []event.VerificationMethod{event.VerificationMethodQRCodeShow, event.VerificationMethodQRCodeScan, event.VerificationMethodReciprocate, event.VerificationMethodSAS}},
-	}
-
-	for i, tc := range testCases {
-		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
-			ts, sendingClient, receivingClient, _, _, sendingMachine, receivingMachine := initServerAndLogin(t, ctx)
-			defer ts.Close()
-
-			recoveryKey, sendingCrossSigningKeysCache, err := sendingMachine.GenerateAndUploadCrossSigningKeys(ctx, nil, "")
-			assert.NoError(t, err)
-			assert.NotEmpty(t, recoveryKey)
-			assert.NotNil(t, sendingCrossSigningKeysCache)
-
-			sendingHelper := verificationhelper.NewVerificationHelper(sendingClient, sendingMachine, tc.sendingCallbacks, tc.sendingSupportsScan)
-			err = sendingHelper.Init(ctx)
-			require.NoError(t, err)
-
-			receivingHelper := verificationhelper.NewVerificationHelper(receivingClient, receivingMachine, tc.receivingCallbacks, tc.receivingSupportsScan)
-			err = receivingHelper.Init(ctx)
-			require.NoError(t, err)
-
-			txnID, err := sendingHelper.StartVerification(ctx, userID)
-			require.NoError(t, err)
-
-			// Process the verification request on the receiving device.
-			ts.dispatchToDevice(t, ctx, receivingClient)
-
-			// Ensure that the receiving device received a verification
-			// request with the correct transaction ID.
-			assert.ElementsMatch(t, []id.VerificationTransactionID{txnID}, tc.receivingCallbacks.GetRequestedVerifications()[userID])
-
-			// Have the receiving device accept the verification request.
-			err = receivingHelper.AcceptVerification(ctx, txnID)
-			require.NoError(t, err)
-
-			_, sendingIsQRCallbacks := tc.sendingCallbacks.(*qrCodeVerificationCallbacks)
-			_, sendingIsAllCallbacks := tc.sendingCallbacks.(*allVerificationCallbacks)
-			sendingCanShowQR := sendingIsQRCallbacks || sendingIsAllCallbacks
-			_, receivingIsQRCallbacks := tc.receivingCallbacks.(*qrCodeVerificationCallbacks)
-			_, receivingIsAllCallbacks := tc.receivingCallbacks.(*allVerificationCallbacks)
-			receivingCanShowQR := receivingIsQRCallbacks || receivingIsAllCallbacks
-
-			// Ensure that if the receiving device should show a QR code that
-			// it has the correct content.
-			if tc.sendingSupportsScan && receivingCanShowQR {
-				receivingShownQRCode := tc.receivingCallbacks.GetQRCodeShown(txnID)
-				require.NotNil(t, receivingShownQRCode)
-				assert.Equal(t, txnID, receivingShownQRCode.TransactionID)
-				assert.NotEmpty(t, receivingShownQRCode.SharedSecret)
-			}
-
-			// Check for whether the receiving device should be scanning a QR
-			// code.
-			if tc.receivingSupportsScan && sendingCanShowQR {
-				assert.Contains(t, tc.receivingCallbacks.GetScanQRCodeTransactions(), txnID)
-			}
-
-			// Check that the m.key.verification.ready event has the correct
-			// content.
-			sendingInbox := ts.DeviceInbox[userID][sendingDeviceID]
-			assert.Len(t, sendingInbox, 1)
-			readyEvt := sendingInbox[0].Content.AsVerificationReady()
-			assert.Equal(t, txnID, readyEvt.TransactionID)
-			assert.Equal(t, receivingDeviceID, readyEvt.FromDevice)
-			assert.ElementsMatch(t, tc.expectedVerificationMethods, readyEvt.Methods)
-
-			// Receive the m.key.verification.ready event on the sending
-			// device.
-			ts.dispatchToDevice(t, ctx, sendingClient)
-
-			// Ensure that if the sending device should show a QR code that it
-			// has the correct content.
-			if tc.receivingSupportsScan && sendingCanShowQR {
-				sendingShownQRCode := tc.sendingCallbacks.GetQRCodeShown(txnID)
-				require.NotNil(t, sendingShownQRCode)
-				assert.Equal(t, txnID, sendingShownQRCode.TransactionID)
-				assert.NotEmpty(t, sendingShownQRCode.SharedSecret)
-			}
-
-			// Check for whether the sending device should be scanning a QR
-			// code.
-			if tc.sendingSupportsScan && receivingCanShowQR {
-				assert.Contains(t, tc.sendingCallbacks.GetScanQRCodeTransactions(), txnID)
-			}
-		})
-	}
-}
 
 func TestSelfVerification_Accept_QRContents(t *testing.T) {
 	ctx := log.Logger.WithContext(context.TODO())
@@ -312,7 +60,7 @@ func TestSelfVerification_Accept_QRContents(t *testing.T) {
 			// Send the verification request from the sender device and accept
 			// it on the receiving device and receive the verification ready
 			// event on the sending device.
-			txnID, err := sendingHelper.StartVerification(ctx, userID)
+			txnID, err := sendingHelper.StartVerification(ctx, aliceUserID)
 			require.NoError(t, err)
 			ts.dispatchToDevice(t, ctx, receivingClient)
 
@@ -371,50 +119,6 @@ func TestSelfVerification_Accept_QRContents(t *testing.T) {
 	}
 }
 
-// TestAcceptSelfVerificationCancelOnNonParticipatingDevices ensures that we do
-// not regress https://github.com/mautrix/go/pull/230.
-func TestSelfVerification_Accept_CancelOnNonParticipatingDevices(t *testing.T) {
-	ctx := log.Logger.WithContext(context.TODO())
-	ts, sendingClient, receivingClient, sendingCryptoStore, receivingCryptoStore, sendingMachine, receivingMachine := initServerAndLogin(t, ctx)
-	defer ts.Close()
-	_, _, sendingHelper, receivingHelper := initDefaultCallbacks(t, ctx, sendingClient, receivingClient, sendingMachine, receivingMachine)
-
-	nonParticipatingDeviceID1 := id.DeviceID("non-participating1")
-	nonParticipatingDeviceID2 := id.DeviceID("non-participating2")
-	addDeviceID(ctx, sendingCryptoStore, userID, nonParticipatingDeviceID1)
-	addDeviceID(ctx, sendingCryptoStore, userID, nonParticipatingDeviceID2)
-	addDeviceID(ctx, receivingCryptoStore, userID, nonParticipatingDeviceID1)
-	addDeviceID(ctx, receivingCryptoStore, userID, nonParticipatingDeviceID2)
-
-	_, _, err := sendingMachine.GenerateAndUploadCrossSigningKeys(ctx, nil, "")
-	assert.NoError(t, err)
-
-	// Send the verification request from the sender device and accept it on
-	// the receiving device.
-	txnID, err := sendingHelper.StartVerification(ctx, userID)
-	require.NoError(t, err)
-	ts.dispatchToDevice(t, ctx, receivingClient)
-	err = receivingHelper.AcceptVerification(ctx, txnID)
-	require.NoError(t, err)
-
-	// Receive the m.key.verification.ready event on the sending device.
-	ts.dispatchToDevice(t, ctx, sendingClient)
-
-	// The sending and receiving devices should not have any cancellation
-	// events in their inboxes.
-	assert.Empty(t, ts.DeviceInbox[userID][sendingDeviceID])
-	assert.Empty(t, ts.DeviceInbox[userID][receivingDeviceID])
-
-	// There should now be cancellation events in the non-participating devices
-	// inboxes (in addition to the request event).
-	assert.Len(t, ts.DeviceInbox[userID][nonParticipatingDeviceID1], 2)
-	assert.Len(t, ts.DeviceInbox[userID][nonParticipatingDeviceID2], 2)
-	assert.Equal(t, ts.DeviceInbox[userID][nonParticipatingDeviceID1][1], ts.DeviceInbox[userID][nonParticipatingDeviceID2][1])
-	cancellationEvent := ts.DeviceInbox[userID][nonParticipatingDeviceID1][1].Content.AsVerificationCancel()
-	assert.Equal(t, txnID, cancellationEvent.TransactionID)
-	assert.Equal(t, event.VerificationCancelCodeAccepted, cancellationEvent.Code)
-}
-
 func TestSelfVerification_ScanQRAndConfirmScan(t *testing.T) {
 	ctx := log.Logger.WithContext(context.TODO())
 
@@ -446,7 +150,7 @@ func TestSelfVerification_ScanQRAndConfirmScan(t *testing.T) {
 			// Send the verification request from the sender device and accept
 			// it on the receiving device and receive the verification ready
 			// event on the sending device.
-			txnID, err := sendingHelper.StartVerification(ctx, userID)
+			txnID, err := sendingHelper.StartVerification(ctx, aliceUserID)
 			require.NoError(t, err)
 			ts.dispatchToDevice(t, ctx, receivingClient)
 			err = receivingHelper.AcceptVerification(ctx, txnID)
@@ -466,7 +170,7 @@ func TestSelfVerification_ScanQRAndConfirmScan(t *testing.T) {
 
 				// Ensure that the receiving device received a verification
 				// start event and a verification done event.
-				receivingInbox := ts.DeviceInbox[userID][receivingDeviceID]
+				receivingInbox := ts.DeviceInbox[aliceUserID][receivingDeviceID]
 				assert.Len(t, receivingInbox, 2)
 
 				startEvt := receivingInbox[0].Content.AsVerificationStart()
@@ -490,7 +194,7 @@ func TestSelfVerification_ScanQRAndConfirmScan(t *testing.T) {
 
 				// Ensure that the sending device received a verification done
 				// event.
-				sendingInbox := ts.DeviceInbox[userID][sendingDeviceID]
+				sendingInbox := ts.DeviceInbox[aliceUserID][sendingDeviceID]
 				require.Len(t, sendingInbox, 1)
 				doneEvt = sendingInbox[0].Content.AsVerificationDone()
 				assert.Equal(t, txnID, doneEvt.TransactionID)
@@ -504,7 +208,7 @@ func TestSelfVerification_ScanQRAndConfirmScan(t *testing.T) {
 
 				// Ensure that the sending device received a verification
 				// start event and a verification done event.
-				sendingInbox := ts.DeviceInbox[userID][sendingDeviceID]
+				sendingInbox := ts.DeviceInbox[aliceUserID][sendingDeviceID]
 				assert.Len(t, sendingInbox, 2)
 
 				startEvt := sendingInbox[0].Content.AsVerificationStart()
@@ -528,7 +232,7 @@ func TestSelfVerification_ScanQRAndConfirmScan(t *testing.T) {
 
 				// Ensure that the receiving device received a verification
 				// done event.
-				receivingInbox := ts.DeviceInbox[userID][receivingDeviceID]
+				receivingInbox := ts.DeviceInbox[aliceUserID][receivingDeviceID]
 				require.Len(t, receivingInbox, 1)
 				doneEvt = receivingInbox[0].Content.AsVerificationDone()
 				assert.Equal(t, txnID, doneEvt.TransactionID)
@@ -541,24 +245,6 @@ func TestSelfVerification_ScanQRAndConfirmScan(t *testing.T) {
 			assert.True(t, receivingCallbacks.IsVerificationDone(txnID))
 		})
 	}
-}
-
-func TestSelfVerification_ErrorOnDoubleAccept(t *testing.T) {
-	ctx := log.Logger.WithContext(context.TODO())
-	ts, sendingClient, receivingClient, _, _, sendingMachine, receivingMachine := initServerAndLogin(t, ctx)
-	defer ts.Close()
-	_, _, sendingHelper, receivingHelper := initDefaultCallbacks(t, ctx, sendingClient, receivingClient, sendingMachine, receivingMachine)
-
-	_, _, err := sendingMachine.GenerateAndUploadCrossSigningKeys(ctx, nil, "")
-	require.NoError(t, err)
-
-	txnID, err := sendingHelper.StartVerification(ctx, userID)
-	require.NoError(t, err)
-	ts.dispatchToDevice(t, ctx, receivingClient)
-	err = receivingHelper.AcceptVerification(ctx, txnID)
-	require.NoError(t, err)
-	err = receivingHelper.AcceptVerification(ctx, txnID)
-	require.ErrorContains(t, err, "transaction is not in the requested state")
 }
 
 func TestSelfVerification_ScanQRTransactionIDCorrupted(t *testing.T) {
@@ -575,7 +261,7 @@ func TestSelfVerification_ScanQRTransactionIDCorrupted(t *testing.T) {
 	// Send the verification request from the sender device and accept
 	// it on the receiving device and receive the verification ready
 	// event on the sending device.
-	txnID, err := sendingHelper.StartVerification(ctx, userID)
+	txnID, err := sendingHelper.StartVerification(ctx, aliceUserID)
 	require.NoError(t, err)
 	ts.dispatchToDevice(t, ctx, receivingClient)
 	err = receivingHelper.AcceptVerification(ctx, txnID)
@@ -639,7 +325,7 @@ func TestSelfVerification_ScanQRKeyCorrupted(t *testing.T) {
 			// Send the verification request from the sender device and accept
 			// it on the receiving device and receive the verification ready
 			// event on the sending device.
-			txnID, err := sendingHelper.StartVerification(ctx, userID)
+			txnID, err := sendingHelper.StartVerification(ctx, aliceUserID)
 			require.NoError(t, err)
 			ts.dispatchToDevice(t, ctx, receivingClient)
 			err = receivingHelper.AcceptVerification(ctx, txnID)
@@ -660,7 +346,7 @@ func TestSelfVerification_ScanQRKeyCorrupted(t *testing.T) {
 				assert.ErrorContains(t, err, tc.expectedError)
 
 				// Ensure that the receiving device received a cancellation.
-				receivingInbox := ts.DeviceInbox[userID][receivingDeviceID]
+				receivingInbox := ts.DeviceInbox[aliceUserID][receivingDeviceID]
 				assert.Len(t, receivingInbox, 1)
 				ts.dispatchToDevice(t, ctx, receivingClient)
 				cancellation := receivingCallbacks.GetVerificationCancellation(txnID)
@@ -674,7 +360,7 @@ func TestSelfVerification_ScanQRKeyCorrupted(t *testing.T) {
 				assert.ErrorContains(t, err, tc.expectedError)
 
 				// Ensure that the sending device received a cancellation.
-				sendingInbox := ts.DeviceInbox[userID][sendingDeviceID]
+				sendingInbox := ts.DeviceInbox[aliceUserID][sendingDeviceID]
 				assert.Len(t, sendingInbox, 1)
 				ts.dispatchToDevice(t, ctx, sendingClient)
 				cancellation := sendingCallbacks.GetVerificationCancellation(txnID)

--- a/crypto/verificationhelper/verificationhelper_sas_test.go
+++ b/crypto/verificationhelper/verificationhelper_sas_test.go
@@ -1,0 +1,278 @@
+package verificationhelper_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/rs/zerolog/log"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/exp/maps"
+
+	"maunium.net/go/mautrix/crypto"
+	"maunium.net/go/mautrix/event"
+	"maunium.net/go/mautrix/id"
+)
+
+func TestVerification_SAS(t *testing.T) {
+	ctx := log.Logger.WithContext(context.TODO())
+
+	testCases := []struct {
+		sendingGeneratedCrossSigningKeys bool
+		sendingStartsSAS                 bool
+		sendingConfirmsFirst             bool
+	}{
+		{true, true, true},
+		{true, true, false},
+		{true, false, true},
+		{true, false, false},
+		{false, true, true},
+		{false, true, false},
+		{false, false, true},
+		{false, false, false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("sendingGenerated=%t sendingStartsSAS=%t sendingConfirmsFirst=%t", tc.sendingGeneratedCrossSigningKeys, tc.sendingStartsSAS, tc.sendingConfirmsFirst), func(t *testing.T) {
+			ts, sendingClient, receivingClient, _, _, sendingMachine, receivingMachine := initServerAndLogin(t, ctx)
+			defer ts.Close()
+			sendingCallbacks, receivingCallbacks, sendingHelper, receivingHelper := initDefaultCallbacks(t, ctx, sendingClient, receivingClient, sendingMachine, receivingMachine)
+			var err error
+
+			var sendingRecoveryKey, receivingRecoveryKey string
+			var sendingCrossSigningKeysCache, receivingCrossSigningKeysCache *crypto.CrossSigningKeysCache
+
+			if tc.sendingGeneratedCrossSigningKeys {
+				sendingRecoveryKey, sendingCrossSigningKeysCache, err = sendingMachine.GenerateAndUploadCrossSigningKeys(ctx, nil, "")
+				require.NoError(t, err)
+				assert.NotEmpty(t, sendingRecoveryKey)
+				assert.NotNil(t, sendingCrossSigningKeysCache)
+			} else {
+				receivingRecoveryKey, receivingCrossSigningKeysCache, err = receivingMachine.GenerateAndUploadCrossSigningKeys(ctx, nil, "")
+				require.NoError(t, err)
+				assert.NotEmpty(t, receivingRecoveryKey)
+				assert.NotNil(t, receivingCrossSigningKeysCache)
+			}
+
+			// Send the verification request from the sender device and accept
+			// it on the receiving device and receive the verification ready
+			// event on the sending device.
+			txnID, err := sendingHelper.StartVerification(ctx, aliceUserID)
+			require.NoError(t, err)
+			ts.dispatchToDevice(t, ctx, receivingClient)
+			err = receivingHelper.AcceptVerification(ctx, txnID)
+			require.NoError(t, err)
+			ts.dispatchToDevice(t, ctx, sendingClient)
+
+			// Test that the start event is correct
+			var startEvt *event.VerificationStartEventContent
+			if tc.sendingStartsSAS {
+				err = sendingHelper.StartSAS(ctx, txnID)
+				require.NoError(t, err)
+
+				// Ensure that the receiving device received a verification
+				// start event.
+				receivingInbox := ts.DeviceInbox[aliceUserID][receivingDeviceID]
+				assert.Len(t, receivingInbox, 1)
+				startEvt = receivingInbox[0].Content.AsVerificationStart()
+				assert.Equal(t, sendingDeviceID, startEvt.FromDevice)
+			} else {
+				err = receivingHelper.StartSAS(ctx, txnID)
+				require.NoError(t, err)
+
+				// Ensure that the receiving device received a verification
+				// start event.
+				sendingInbox := ts.DeviceInbox[aliceUserID][sendingDeviceID]
+				assert.Len(t, sendingInbox, 1)
+				startEvt = sendingInbox[0].Content.AsVerificationStart()
+				assert.Equal(t, receivingDeviceID, startEvt.FromDevice)
+			}
+			assert.Equal(t, txnID, startEvt.TransactionID)
+			assert.Equal(t, event.VerificationMethodSAS, startEvt.Method)
+			assert.Contains(t, startEvt.Hashes, event.VerificationHashMethodSHA256)
+			assert.Contains(t, startEvt.KeyAgreementProtocols, event.KeyAgreementProtocolCurve25519HKDFSHA256)
+			assert.Contains(t, startEvt.MessageAuthenticationCodes, event.MACMethodHKDFHMACSHA256)
+			assert.Contains(t, startEvt.MessageAuthenticationCodes, event.MACMethodHKDFHMACSHA256V2)
+			assert.Contains(t, startEvt.ShortAuthenticationString, event.SASMethodDecimal)
+			assert.Contains(t, startEvt.ShortAuthenticationString, event.SASMethodEmoji)
+
+			// Test that the accept event is correct
+			var acceptEvt *event.VerificationAcceptEventContent
+			if tc.sendingStartsSAS {
+				// Process the verification start event on the receiving
+				// device.
+				ts.dispatchToDevice(t, ctx, receivingClient)
+
+				// Receiving device sent the accept event to the sending device
+				sendingInbox := ts.DeviceInbox[aliceUserID][sendingDeviceID]
+				assert.Len(t, sendingInbox, 1)
+				acceptEvt = sendingInbox[0].Content.AsVerificationAccept()
+			} else {
+				// Process the verification start event on the sending device.
+				ts.dispatchToDevice(t, ctx, sendingClient)
+
+				// Sending device sent the accept event to the receiving device
+				receivingInbox := ts.DeviceInbox[aliceUserID][receivingDeviceID]
+				assert.Len(t, receivingInbox, 1)
+				acceptEvt = receivingInbox[0].Content.AsVerificationAccept()
+			}
+			assert.Equal(t, txnID, acceptEvt.TransactionID)
+			assert.Equal(t, acceptEvt.Hash, event.VerificationHashMethodSHA256)
+			assert.Equal(t, acceptEvt.KeyAgreementProtocol, event.KeyAgreementProtocolCurve25519HKDFSHA256)
+			assert.Equal(t, acceptEvt.MessageAuthenticationCode, event.MACMethodHKDFHMACSHA256V2)
+			assert.Contains(t, acceptEvt.ShortAuthenticationString, event.SASMethodDecimal)
+			assert.Contains(t, acceptEvt.ShortAuthenticationString, event.SASMethodEmoji)
+			assert.NotEmpty(t, acceptEvt.Commitment)
+
+			// Test that the first key event is correct
+			var firstKeyEvt *event.VerificationKeyEventContent
+			if tc.sendingStartsSAS {
+				// Process the verification accept event on the sending device.
+				ts.dispatchToDevice(t, ctx, sendingClient)
+
+				// Sending device sends first key event to the receiving
+				// device.
+				receivingInbox := ts.DeviceInbox[aliceUserID][receivingDeviceID]
+				assert.Len(t, receivingInbox, 1)
+				firstKeyEvt = receivingInbox[0].Content.AsVerificationKey()
+			} else {
+				// Process the verification accept event on the receiving
+				// device.
+				ts.dispatchToDevice(t, ctx, receivingClient)
+
+				// Receiving device sends first key event to the sending
+				// device.
+				sendingInbox := ts.DeviceInbox[aliceUserID][sendingDeviceID]
+				assert.Len(t, sendingInbox, 1)
+				firstKeyEvt = sendingInbox[0].Content.AsVerificationKey()
+			}
+			assert.Equal(t, txnID, firstKeyEvt.TransactionID)
+			assert.NotEmpty(t, firstKeyEvt.Key)
+			assert.Len(t, firstKeyEvt.Key, 32)
+
+			// Test that the second key event is correct
+			var secondKeyEvt *event.VerificationKeyEventContent
+			if tc.sendingStartsSAS {
+				// Process the first key event on the receiving device.
+				ts.dispatchToDevice(t, ctx, receivingClient)
+
+				// Receiving device sends second key event to the sending
+				// device.
+				sendingInbox := ts.DeviceInbox[aliceUserID][sendingDeviceID]
+				assert.Len(t, sendingInbox, 1)
+				secondKeyEvt = sendingInbox[0].Content.AsVerificationKey()
+
+				// Ensure that the receiving device showed emojis and SAS numbers.
+				assert.Len(t, receivingCallbacks.GetDecimalsShown(txnID), 3)
+				assert.Len(t, receivingCallbacks.GetEmojisShown(txnID), 7)
+			} else {
+				// Process the first key event on the sending device.
+				ts.dispatchToDevice(t, ctx, sendingClient)
+
+				// Sending device sends second key event to the receiving
+				// device.
+				receivingInbox := ts.DeviceInbox[aliceUserID][receivingDeviceID]
+				assert.Len(t, receivingInbox, 1)
+				secondKeyEvt = receivingInbox[0].Content.AsVerificationKey()
+
+				// Ensure that the sending device showed emojis and SAS numbers.
+				assert.Len(t, sendingCallbacks.GetDecimalsShown(txnID), 3)
+				assert.Len(t, sendingCallbacks.GetEmojisShown(txnID), 7)
+			}
+			assert.Equal(t, txnID, secondKeyEvt.TransactionID)
+			assert.NotEmpty(t, secondKeyEvt.Key)
+			assert.Len(t, secondKeyEvt.Key, 32)
+
+			// Ensure that the SAS codes are the same.
+			if tc.sendingStartsSAS {
+				// Process the second key event on the sending device.
+				ts.dispatchToDevice(t, ctx, sendingClient)
+			} else {
+				// Process the second key event on the receiving device.
+				ts.dispatchToDevice(t, ctx, receivingClient)
+			}
+			assert.Equal(t, sendingCallbacks.GetDecimalsShown(txnID), receivingCallbacks.GetDecimalsShown(txnID))
+			assert.Equal(t, sendingCallbacks.GetEmojisShown(txnID), receivingCallbacks.GetEmojisShown(txnID))
+
+			// Test that the first MAC event is correct
+			var firstMACEvt *event.VerificationMACEventContent
+			if tc.sendingConfirmsFirst {
+				err = sendingHelper.ConfirmSAS(ctx, txnID)
+				require.NoError(t, err)
+
+				// The receiving device should have received the MAC event.
+				receivingInbox := ts.DeviceInbox[aliceUserID][receivingDeviceID]
+				assert.Len(t, receivingInbox, 1)
+				firstMACEvt = receivingInbox[0].Content.AsVerificationMAC()
+
+				// The MAC event should have a MAC for the sending device ID.
+				assert.Contains(t, maps.Keys(firstMACEvt.MAC), id.NewKeyID(id.KeyAlgorithmEd25519, sendingDeviceID.String()))
+			} else {
+				err = receivingHelper.ConfirmSAS(ctx, txnID)
+				require.NoError(t, err)
+
+				// The sending device should have received the MAC event.
+				sendingInbox := ts.DeviceInbox[aliceUserID][sendingDeviceID]
+				assert.Len(t, sendingInbox, 1)
+				firstMACEvt = sendingInbox[0].Content.AsVerificationMAC()
+
+				// The MAC event should have a MAC for the receiving device ID.
+				assert.Contains(t, maps.Keys(firstMACEvt.MAC), id.NewKeyID(id.KeyAlgorithmEd25519, receivingDeviceID.String()))
+			}
+			assert.Equal(t, txnID, firstMACEvt.TransactionID)
+
+			// The master key and the sending device ID should be in the
+			// MAC event's mac keys.
+			if tc.sendingGeneratedCrossSigningKeys {
+				assert.Contains(t, maps.Keys(firstMACEvt.MAC), id.NewKeyID(id.KeyAlgorithmEd25519, sendingCrossSigningKeysCache.MasterKey.PublicKey().String()))
+			} else {
+				assert.Contains(t, maps.Keys(firstMACEvt.MAC), id.NewKeyID(id.KeyAlgorithmEd25519, receivingCrossSigningKeysCache.MasterKey.PublicKey().String()))
+			}
+
+			// Test that the second MAC event is correct
+			var secondMACEvt *event.VerificationMACEventContent
+			if tc.sendingConfirmsFirst {
+				err = receivingHelper.ConfirmSAS(ctx, txnID)
+				require.NoError(t, err)
+
+				// The sending device should have received the MAC event.
+				sendingInbox := ts.DeviceInbox[aliceUserID][sendingDeviceID]
+				assert.Len(t, sendingInbox, 1)
+				secondMACEvt = sendingInbox[0].Content.AsVerificationMAC()
+
+				// The MAC event should have a MAC for the receiving device ID.
+				assert.Contains(t, maps.Keys(secondMACEvt.MAC), id.NewKeyID(id.KeyAlgorithmEd25519, receivingDeviceID.String()))
+			} else {
+				err = sendingHelper.ConfirmSAS(ctx, txnID)
+				require.NoError(t, err)
+
+				// The receiving device should have received the MAC event.
+				receivingInbox := ts.DeviceInbox[aliceUserID][receivingDeviceID]
+				assert.Len(t, receivingInbox, 1)
+				secondMACEvt = receivingInbox[0].Content.AsVerificationMAC()
+
+				// The MAC event should have a MAC for the sending device ID.
+				assert.Contains(t, maps.Keys(secondMACEvt.MAC), id.NewKeyID(id.KeyAlgorithmEd25519, sendingDeviceID.String()))
+			}
+			assert.Equal(t, txnID, secondMACEvt.TransactionID)
+
+			// The master key and the sending device ID should be in the
+			// MAC event's mac keys.
+			if tc.sendingGeneratedCrossSigningKeys {
+				assert.Contains(t, maps.Keys(firstMACEvt.MAC), id.NewKeyID(id.KeyAlgorithmEd25519, sendingCrossSigningKeysCache.MasterKey.PublicKey().String()))
+			} else {
+				assert.Contains(t, maps.Keys(firstMACEvt.MAC), id.NewKeyID(id.KeyAlgorithmEd25519, receivingCrossSigningKeysCache.MasterKey.PublicKey().String()))
+			}
+
+			// Test the transaction is done on both sides. We have to dispatch
+			// twice to process and drain all of the events.
+			ts.dispatchToDevice(t, ctx, sendingClient)
+			ts.dispatchToDevice(t, ctx, receivingClient)
+			ts.dispatchToDevice(t, ctx, sendingClient)
+			ts.dispatchToDevice(t, ctx, receivingClient)
+			assert.True(t, sendingCallbacks.IsVerificationDone(txnID))
+			assert.True(t, receivingCallbacks.IsVerificationDone(txnID))
+		})
+	}
+}

--- a/crypto/verificationhelper/verificationhelper_sas_test.go
+++ b/crypto/verificationhelper/verificationhelper_sas_test.go
@@ -35,7 +35,7 @@ func TestVerification_SAS(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(fmt.Sprintf("sendingGenerated=%t sendingStartsSAS=%t sendingConfirmsFirst=%t", tc.sendingGeneratedCrossSigningKeys, tc.sendingStartsSAS, tc.sendingConfirmsFirst), func(t *testing.T) {
-			ts, sendingClient, receivingClient, _, _, sendingMachine, receivingMachine := initServerAndLogin(t, ctx)
+			ts, sendingClient, receivingClient, _, _, sendingMachine, receivingMachine := initServerAndLoginTwoAlice(t, ctx)
 			defer ts.Close()
 			sendingCallbacks, receivingCallbacks, sendingHelper, receivingHelper := initDefaultCallbacks(t, ctx, sendingClient, receivingClient, sendingMachine, receivingMachine)
 			var err error

--- a/crypto/verificationhelper/verificationhelper_test.go
+++ b/crypto/verificationhelper/verificationhelper_test.go
@@ -1,0 +1,329 @@
+package verificationhelper_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"maunium.net/go/mautrix"
+	"maunium.net/go/mautrix/crypto"
+	"maunium.net/go/mautrix/crypto/cryptohelper"
+	"maunium.net/go/mautrix/crypto/verificationhelper"
+	"maunium.net/go/mautrix/event"
+	"maunium.net/go/mautrix/id"
+)
+
+var aliceUserID = id.UserID("@alice:example.org")
+var sendingDeviceID = id.DeviceID("sending")
+var receivingDeviceID = id.DeviceID("receiving")
+
+func init() {
+	log.Logger = zerolog.New(zerolog.ConsoleWriter{Out: os.Stdout, TimeFormat: time.RFC3339}).With().Timestamp().Logger().Level(zerolog.TraceLevel)
+	zerolog.DefaultContextLogger = &log.Logger
+}
+
+func initServerAndLogin(t *testing.T, ctx context.Context) (ts *mockServer, sendingClient, receivingClient *mautrix.Client, sendingCryptoStore, receivingCryptoStore crypto.Store, sendingMachine, receivingMachine *crypto.OlmMachine) {
+	t.Helper()
+	ts = createMockServer(t)
+
+	sendingClient, sendingCryptoStore = ts.Login(t, ctx, aliceUserID, sendingDeviceID)
+	sendingMachine = sendingClient.Crypto.(*cryptohelper.CryptoHelper).Machine()
+	receivingClient, receivingCryptoStore = ts.Login(t, ctx, aliceUserID, receivingDeviceID)
+	receivingMachine = receivingClient.Crypto.(*cryptohelper.CryptoHelper).Machine()
+
+	err := sendingCryptoStore.PutDevice(ctx, aliceUserID, sendingMachine.OwnIdentity())
+	require.NoError(t, err)
+	err = sendingCryptoStore.PutDevice(ctx, aliceUserID, receivingMachine.OwnIdentity())
+	require.NoError(t, err)
+	err = receivingCryptoStore.PutDevice(ctx, aliceUserID, sendingMachine.OwnIdentity())
+	require.NoError(t, err)
+	err = receivingCryptoStore.PutDevice(ctx, aliceUserID, receivingMachine.OwnIdentity())
+	require.NoError(t, err)
+	return
+}
+
+func initDefaultCallbacks(t *testing.T, ctx context.Context, sendingClient, receivingClient *mautrix.Client, sendingMachine, receivingMachine *crypto.OlmMachine) (sendingCallbacks, receivingCallbacks *allVerificationCallbacks, sendingHelper, receivingHelper *verificationhelper.VerificationHelper) {
+	t.Helper()
+	sendingCallbacks = newAllVerificationCallbacks()
+	sendingHelper = verificationhelper.NewVerificationHelper(sendingClient, sendingMachine, sendingCallbacks, true)
+	require.NoError(t, sendingHelper.Init(ctx))
+
+	receivingCallbacks = newAllVerificationCallbacks()
+	receivingHelper = verificationhelper.NewVerificationHelper(receivingClient, receivingMachine, receivingCallbacks, true)
+	require.NoError(t, receivingHelper.Init(ctx))
+	return
+}
+
+func TestVerification_Start(t *testing.T) {
+	ctx := log.Logger.WithContext(context.TODO())
+	receivingDeviceID2 := id.DeviceID("receiving2")
+
+	testCases := []struct {
+		supportsScan                bool
+		callbacks                   MockVerificationCallbacks
+		startVerificationErrMsg     string
+		expectedVerificationMethods []event.VerificationMethod
+	}{
+		{false, newBaseVerificationCallbacks(), "no supported verification methods", nil},
+		{true, newBaseVerificationCallbacks(), "", []event.VerificationMethod{event.VerificationMethodQRCodeScan, event.VerificationMethodReciprocate}},
+		{false, newSASVerificationCallbacks(), "", []event.VerificationMethod{event.VerificationMethodSAS}},
+		{true, newSASVerificationCallbacks(), "", []event.VerificationMethod{event.VerificationMethodQRCodeScan, event.VerificationMethodReciprocate, event.VerificationMethodSAS}},
+		{true, newQRCodeVerificationCallbacks(), "", []event.VerificationMethod{event.VerificationMethodQRCodeScan, event.VerificationMethodQRCodeShow, event.VerificationMethodReciprocate}},
+		{false, newQRCodeVerificationCallbacks(), "", []event.VerificationMethod{event.VerificationMethodQRCodeShow, event.VerificationMethodReciprocate}},
+		{false, newAllVerificationCallbacks(), "", []event.VerificationMethod{event.VerificationMethodQRCodeShow, event.VerificationMethodReciprocate, event.VerificationMethodSAS}},
+		{true, newAllVerificationCallbacks(), "", []event.VerificationMethod{event.VerificationMethodQRCodeScan, event.VerificationMethodQRCodeShow, event.VerificationMethodReciprocate, event.VerificationMethodSAS}},
+	}
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			ts := createMockServer(t)
+			defer ts.Close()
+
+			client, cryptoStore := ts.Login(t, ctx, aliceUserID, sendingDeviceID)
+			addDeviceID(ctx, cryptoStore, aliceUserID, sendingDeviceID)
+			addDeviceID(ctx, cryptoStore, aliceUserID, receivingDeviceID)
+			addDeviceID(ctx, cryptoStore, aliceUserID, receivingDeviceID2)
+
+			senderHelper := verificationhelper.NewVerificationHelper(client, client.Crypto.(*cryptohelper.CryptoHelper).Machine(), tc.callbacks, tc.supportsScan)
+			err := senderHelper.Init(ctx)
+			require.NoError(t, err)
+
+			txnID, err := senderHelper.StartVerification(ctx, aliceUserID)
+			if tc.startVerificationErrMsg != "" {
+				assert.ErrorContains(t, err, tc.startVerificationErrMsg)
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.NotEmpty(t, txnID)
+
+			toDeviceInbox := ts.DeviceInbox[aliceUserID]
+
+			// Ensure that we didn't send a verification request to the
+			// sending device.
+			assert.Empty(t, toDeviceInbox[sendingDeviceID])
+
+			// Ensure that the verification request was sent to both of
+			// the other devices.
+			assert.NotEmpty(t, toDeviceInbox[receivingDeviceID])
+			assert.NotEmpty(t, toDeviceInbox[receivingDeviceID2])
+			assert.Equal(t, toDeviceInbox[receivingDeviceID], toDeviceInbox[receivingDeviceID2])
+			assert.Len(t, toDeviceInbox[receivingDeviceID], 1)
+
+			// Ensure that the verification request is correct.
+			verificationRequest := toDeviceInbox[receivingDeviceID][0].Content.AsVerificationRequest()
+			assert.Equal(t, sendingDeviceID, verificationRequest.FromDevice)
+			assert.Equal(t, txnID, verificationRequest.TransactionID)
+			assert.ElementsMatch(t, tc.expectedVerificationMethods, verificationRequest.Methods)
+		})
+	}
+}
+
+func TestVerification_Accept_NoSupportedMethods(t *testing.T) {
+	ctx := log.Logger.WithContext(context.TODO())
+
+	ts := createMockServer(t)
+	defer ts.Close()
+
+	sendingClient, sendingCryptoStore := ts.Login(t, ctx, aliceUserID, sendingDeviceID)
+	receivingClient, _ := ts.Login(t, ctx, aliceUserID, receivingDeviceID)
+	addDeviceID(ctx, sendingCryptoStore, aliceUserID, sendingDeviceID)
+	addDeviceID(ctx, sendingCryptoStore, aliceUserID, receivingDeviceID)
+
+	sendingMachine := sendingClient.Crypto.(*cryptohelper.CryptoHelper).Machine()
+	recoveryKey, cache, err := sendingMachine.GenerateAndUploadCrossSigningKeys(ctx, nil, "")
+	assert.NoError(t, err)
+	assert.NotEmpty(t, recoveryKey)
+	assert.NotNil(t, cache)
+
+	sendingHelper := verificationhelper.NewVerificationHelper(sendingClient, sendingMachine, newAllVerificationCallbacks(), true)
+	err = sendingHelper.Init(ctx)
+	require.NoError(t, err)
+
+	receivingCallbacks := newBaseVerificationCallbacks()
+	receivingHelper := verificationhelper.NewVerificationHelper(receivingClient, receivingClient.Crypto.(*cryptohelper.CryptoHelper).Machine(), receivingCallbacks, false)
+	err = receivingHelper.Init(ctx)
+	require.NoError(t, err)
+
+	txnID, err := sendingHelper.StartVerification(ctx, aliceUserID)
+	require.NoError(t, err)
+	require.NotEmpty(t, txnID)
+
+	ts.dispatchToDevice(t, ctx, receivingClient)
+
+	// Ensure that the receiver ignored the request because it
+	// doesn't support any of the verification methods in the
+	// request.
+	assert.Empty(t, receivingCallbacks.GetRequestedVerifications())
+}
+
+func TestVerification_Accept_CorrectMethodsPresented(t *testing.T) {
+	ctx := log.Logger.WithContext(context.TODO())
+
+	testCases := []struct {
+		sendingSupportsScan         bool
+		receivingSupportsScan       bool
+		sendingCallbacks            MockVerificationCallbacks
+		receivingCallbacks          MockVerificationCallbacks
+		expectedVerificationMethods []event.VerificationMethod
+	}{
+		{false, false, newSASVerificationCallbacks(), newSASVerificationCallbacks(), []event.VerificationMethod{event.VerificationMethodSAS}},
+		{true, false, newQRCodeVerificationCallbacks(), newQRCodeVerificationCallbacks(), []event.VerificationMethod{event.VerificationMethodQRCodeShow, event.VerificationMethodReciprocate}},
+		{false, true, newQRCodeVerificationCallbacks(), newQRCodeVerificationCallbacks(), []event.VerificationMethod{event.VerificationMethodQRCodeScan, event.VerificationMethodReciprocate}},
+		{true, false, newAllVerificationCallbacks(), newAllVerificationCallbacks(), []event.VerificationMethod{event.VerificationMethodQRCodeShow, event.VerificationMethodReciprocate, event.VerificationMethodSAS}},
+		{true, true, newAllVerificationCallbacks(), newAllVerificationCallbacks(), []event.VerificationMethod{event.VerificationMethodQRCodeShow, event.VerificationMethodQRCodeScan, event.VerificationMethodReciprocate, event.VerificationMethodSAS}},
+	}
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			ts, sendingClient, receivingClient, _, _, sendingMachine, receivingMachine := initServerAndLogin(t, ctx)
+			defer ts.Close()
+
+			recoveryKey, sendingCrossSigningKeysCache, err := sendingMachine.GenerateAndUploadCrossSigningKeys(ctx, nil, "")
+			assert.NoError(t, err)
+			assert.NotEmpty(t, recoveryKey)
+			assert.NotNil(t, sendingCrossSigningKeysCache)
+
+			sendingHelper := verificationhelper.NewVerificationHelper(sendingClient, sendingMachine, tc.sendingCallbacks, tc.sendingSupportsScan)
+			err = sendingHelper.Init(ctx)
+			require.NoError(t, err)
+
+			receivingHelper := verificationhelper.NewVerificationHelper(receivingClient, receivingMachine, tc.receivingCallbacks, tc.receivingSupportsScan)
+			err = receivingHelper.Init(ctx)
+			require.NoError(t, err)
+
+			txnID, err := sendingHelper.StartVerification(ctx, aliceUserID)
+			require.NoError(t, err)
+
+			// Process the verification request on the receiving device.
+			ts.dispatchToDevice(t, ctx, receivingClient)
+
+			// Ensure that the receiving device received a verification
+			// request with the correct transaction ID.
+			assert.ElementsMatch(t, []id.VerificationTransactionID{txnID}, tc.receivingCallbacks.GetRequestedVerifications()[aliceUserID])
+
+			// Have the receiving device accept the verification request.
+			err = receivingHelper.AcceptVerification(ctx, txnID)
+			require.NoError(t, err)
+
+			_, sendingIsQRCallbacks := tc.sendingCallbacks.(*qrCodeVerificationCallbacks)
+			_, sendingIsAllCallbacks := tc.sendingCallbacks.(*allVerificationCallbacks)
+			sendingCanShowQR := sendingIsQRCallbacks || sendingIsAllCallbacks
+			_, receivingIsQRCallbacks := tc.receivingCallbacks.(*qrCodeVerificationCallbacks)
+			_, receivingIsAllCallbacks := tc.receivingCallbacks.(*allVerificationCallbacks)
+			receivingCanShowQR := receivingIsQRCallbacks || receivingIsAllCallbacks
+
+			// Ensure that if the receiving device should show a QR code that
+			// it has the correct content.
+			if tc.sendingSupportsScan && receivingCanShowQR {
+				receivingShownQRCode := tc.receivingCallbacks.GetQRCodeShown(txnID)
+				require.NotNil(t, receivingShownQRCode)
+				assert.Equal(t, txnID, receivingShownQRCode.TransactionID)
+				assert.NotEmpty(t, receivingShownQRCode.SharedSecret)
+			}
+
+			// Check for whether the receiving device should be scanning a QR
+			// code.
+			if tc.receivingSupportsScan && sendingCanShowQR {
+				assert.Contains(t, tc.receivingCallbacks.GetScanQRCodeTransactions(), txnID)
+			}
+
+			// Check that the m.key.verification.ready event has the correct
+			// content.
+			sendingInbox := ts.DeviceInbox[aliceUserID][sendingDeviceID]
+			assert.Len(t, sendingInbox, 1)
+			readyEvt := sendingInbox[0].Content.AsVerificationReady()
+			assert.Equal(t, txnID, readyEvt.TransactionID)
+			assert.Equal(t, receivingDeviceID, readyEvt.FromDevice)
+			assert.ElementsMatch(t, tc.expectedVerificationMethods, readyEvt.Methods)
+
+			// Receive the m.key.verification.ready event on the sending
+			// device.
+			ts.dispatchToDevice(t, ctx, sendingClient)
+
+			// Ensure that if the sending device should show a QR code that it
+			// has the correct content.
+			if tc.receivingSupportsScan && sendingCanShowQR {
+				sendingShownQRCode := tc.sendingCallbacks.GetQRCodeShown(txnID)
+				require.NotNil(t, sendingShownQRCode)
+				assert.Equal(t, txnID, sendingShownQRCode.TransactionID)
+				assert.NotEmpty(t, sendingShownQRCode.SharedSecret)
+			}
+
+			// Check for whether the sending device should be scanning a QR
+			// code.
+			if tc.sendingSupportsScan && receivingCanShowQR {
+				assert.Contains(t, tc.sendingCallbacks.GetScanQRCodeTransactions(), txnID)
+			}
+		})
+	}
+}
+
+// TestAcceptSelfVerificationCancelOnNonParticipatingDevices ensures that we do
+// not regress https://github.com/mautrix/go/pull/230.
+func TestVerification_Accept_CancelOnNonParticipatingDevices(t *testing.T) {
+	ctx := log.Logger.WithContext(context.TODO())
+	ts, sendingClient, receivingClient, sendingCryptoStore, receivingCryptoStore, sendingMachine, receivingMachine := initServerAndLogin(t, ctx)
+	defer ts.Close()
+	_, _, sendingHelper, receivingHelper := initDefaultCallbacks(t, ctx, sendingClient, receivingClient, sendingMachine, receivingMachine)
+
+	nonParticipatingDeviceID1 := id.DeviceID("non-participating1")
+	nonParticipatingDeviceID2 := id.DeviceID("non-participating2")
+	addDeviceID(ctx, sendingCryptoStore, aliceUserID, nonParticipatingDeviceID1)
+	addDeviceID(ctx, sendingCryptoStore, aliceUserID, nonParticipatingDeviceID2)
+	addDeviceID(ctx, receivingCryptoStore, aliceUserID, nonParticipatingDeviceID1)
+	addDeviceID(ctx, receivingCryptoStore, aliceUserID, nonParticipatingDeviceID2)
+
+	_, _, err := sendingMachine.GenerateAndUploadCrossSigningKeys(ctx, nil, "")
+	assert.NoError(t, err)
+
+	// Send the verification request from the sender device and accept it on
+	// the receiving device.
+	txnID, err := sendingHelper.StartVerification(ctx, aliceUserID)
+	require.NoError(t, err)
+	ts.dispatchToDevice(t, ctx, receivingClient)
+	err = receivingHelper.AcceptVerification(ctx, txnID)
+	require.NoError(t, err)
+
+	// Receive the m.key.verification.ready event on the sending device.
+	ts.dispatchToDevice(t, ctx, sendingClient)
+
+	// The sending and receiving devices should not have any cancellation
+	// events in their inboxes.
+	assert.Empty(t, ts.DeviceInbox[aliceUserID][sendingDeviceID])
+	assert.Empty(t, ts.DeviceInbox[aliceUserID][receivingDeviceID])
+
+	// There should now be cancellation events in the non-participating devices
+	// inboxes (in addition to the request event).
+	assert.Len(t, ts.DeviceInbox[aliceUserID][nonParticipatingDeviceID1], 2)
+	assert.Len(t, ts.DeviceInbox[aliceUserID][nonParticipatingDeviceID2], 2)
+	assert.Equal(t, ts.DeviceInbox[aliceUserID][nonParticipatingDeviceID1][1], ts.DeviceInbox[aliceUserID][nonParticipatingDeviceID2][1])
+	cancellationEvent := ts.DeviceInbox[aliceUserID][nonParticipatingDeviceID1][1].Content.AsVerificationCancel()
+	assert.Equal(t, txnID, cancellationEvent.TransactionID)
+	assert.Equal(t, event.VerificationCancelCodeAccepted, cancellationEvent.Code)
+}
+
+func TestVerification_ErrorOnDoubleAccept(t *testing.T) {
+	ctx := log.Logger.WithContext(context.TODO())
+	ts, sendingClient, receivingClient, _, _, sendingMachine, receivingMachine := initServerAndLogin(t, ctx)
+	defer ts.Close()
+	_, _, sendingHelper, receivingHelper := initDefaultCallbacks(t, ctx, sendingClient, receivingClient, sendingMachine, receivingMachine)
+
+	_, _, err := sendingMachine.GenerateAndUploadCrossSigningKeys(ctx, nil, "")
+	require.NoError(t, err)
+
+	txnID, err := sendingHelper.StartVerification(ctx, aliceUserID)
+	require.NoError(t, err)
+	ts.dispatchToDevice(t, ctx, receivingClient)
+	err = receivingHelper.AcceptVerification(ctx, txnID)
+	require.NoError(t, err)
+	err = receivingHelper.AcceptVerification(ctx, txnID)
+	require.ErrorContains(t, err, "transaction is not in the requested state")
+}


### PR DESCRIPTION
This PR adds E2E tests for the happy path of the SAS methods of device verification. It also implements cross-signing support via QR codes and adds tests for it.
