### PR TITLE
Check for own cross signing public keys being cached

### DIFF
--- a/crypto/keybackup.go
+++ b/crypto/keybackup.go
@@ -54,6 +54,9 @@ func (mach *OlmMachine) GetAndVerifyLatestKeyBackupVersion(ctx context.Context) 
 	}
 
 	crossSigningPubkeys := mach.GetOwnCrossSigningPublicKeys(ctx)
+	if crossSigningPubkeys == nil {
+		return nil, ErrCrossSigningPubkeysNotCached
+	}
 
 	signatureVerified := false
 	for keyID := range userSignatures {


### PR DESCRIPTION
This PR adds a couple checks to ensure that we have our own cross-signing pubkeys cached in a couple more places. This should prevent some NPEs.
