### PR TITLE
verificationhelper: make auto-cancellations more spec-compliant

### DIFF
--- a/crypto/verificationhelper/reciprocate.go
+++ b/crypto/verificationhelper/reciprocate.go
@@ -177,7 +177,7 @@ func (vh *VerificationHelper) HandleScannedQRData(ctx context.Context, data []by
 	txn.SentOurDone = true
 	if txn.ReceivedTheirDone {
 		log.Debug().Msg("We already received their done event. Setting verification state to done.")
-		txn.VerificationState = verificationStateDone
+		delete(vh.activeTransactions, txn.TransactionID)
 		vh.verificationDone(ctx, txn.TransactionID)
 	}
 	return nil
@@ -244,7 +244,7 @@ func (vh *VerificationHelper) ConfirmQRCodeScanned(ctx context.Context, txnID id
 	}
 	txn.SentOurDone = true
 	if txn.ReceivedTheirDone {
-		txn.VerificationState = verificationStateDone
+		delete(vh.activeTransactions, txn.TransactionID)
 		vh.verificationDone(ctx, txn.TransactionID)
 	}
 	return nil

--- a/crypto/verificationhelper/sas.go
+++ b/crypto/verificationhelper/sas.go
@@ -564,6 +564,8 @@ func (vh *VerificationHelper) onVerificationMAC(ctx context.Context, txn *verifi
 		Str("verification_action", "mac").
 		Logger()
 	log.Info().Msg("Received SAS verification MAC event")
+	vh.activeTransactionsLock.Lock()
+	defer vh.activeTransactionsLock.Unlock()
 	macEvt := evt.Content.AsVerificationMAC()
 
 	// Verifying Keys MAC
@@ -646,8 +648,6 @@ func (vh *VerificationHelper) onVerificationMAC(ctx context.Context, txn *verifi
 	}
 	log.Info().Msg("All MACs verified")
 
-	vh.activeTransactionsLock.Lock()
-	defer vh.activeTransactionsLock.Unlock()
 	txn.ReceivedTheirMAC = true
 	if txn.SentOurMAC {
 		txn.VerificationState = verificationStateSASMACExchanged


### PR DESCRIPTION
* Prevents sending cancellation events in response to cancellation
  events that we don't know about.
* Streamlines sending cancellations for all other unknown-transaction
  cases.
* Ensures that the activeTransactionsLock is locked when calling
  cancelVerificationTxn.

Signed-off-by: Sumner Evans <sumner.evans@automattic.com>
