### PR TITLE
event/powerlevels: use 0 as default required level for invite

### DIFF
--- a/event/powerlevels.go
+++ b/event/powerlevels.go
@@ -96,7 +96,7 @@ func (pl *PowerLevelsEventContent) Invite() int {
 	if pl.InvitePtr != nil {
 		return *pl.InvitePtr
 	}
-	return 50
+	return 0
 }
 
 func (pl *PowerLevelsEventContent) Kick() int {


### PR DESCRIPTION
Hi,

I checked the other power levels and they matched the spec.

Best,
Simon