### PR TITLE
bridgev2/portal: don't shadow redaction remove error

### DIFF
--- a/bridgev2/portal.go
+++ b/bridgev2/portal.go
@@ -897,6 +897,7 @@ func (portal *Portal) handleMatrixRedaction(ctx context.Context, sender *UserLog
 		portal.sendErrorStatus(ctx, evt, ErrRedactionsNotSupported)
 		return
 	}
+	var redactionTargetReaction *database.Reaction
 	redactionTargetMsg, err := portal.Bridge.DB.Message.GetPartByMXID(ctx, content.Redacts)
 	if err != nil {
 		log.Err(err).Msg("Failed to get redaction target message from database")
@@ -917,7 +918,7 @@ func (portal *Portal) handleMatrixRedaction(ctx context.Context, sender *UserLog
 			},
 			TargetMessage: redactionTargetMsg,
 		})
-	} else if redactionTargetReaction, err := portal.Bridge.DB.Reaction.GetByMXID(ctx, content.Redacts); err != nil {
+	} else if redactionTargetReaction, err = portal.Bridge.DB.Reaction.GetByMXID(ctx, content.Redacts); err != nil {
 		log.Err(err).Msg("Failed to get redaction target reaction from database")
 		portal.sendErrorStatus(ctx, evt, fmt.Errorf("%w: failed to get redaction target message reaction: %w", ErrDatabaseError, err))
 		return


### PR DESCRIPTION
The error:
https://github.com/mautrix/go/blob/74c0110ee0e4cc47706e5708c966645a3c07610e/bridgev2/portal.go#L931
refers to the `err` declared here:
https://github.com/mautrix/go/blob/74c0110ee0e4cc47706e5708c966645a3c07610e/bridgev2/portal.go#L920
which shadows the `err` declared here:
https://github.com/mautrix/go/blob/74c0110ee0e4cc47706e5708c966645a3c07610e/bridgev2/portal.go#L900
which is the error that is handled by this line:
https://github.com/mautrix/go/blob/74c0110ee0e4cc47706e5708c966645a3c07610e/bridgev2/portal.go#L945
which means that redaction remove errors are not handled.

This error would have been caught by staticcheck, so we should really try and get the codebase to a point where we can use staticcheck in pre-commit and CI.

Signed-off-by: Sumner Evans <sumner.evans@automattic.com>
