### PR TITLE
Use known room id for local management oroms

### DIFF
--- a/bridgev2/user.go
+++ b/bridgev2/user.go
@@ -220,8 +220,9 @@ func (user *User) GetManagementRoom(ctx context.Context) (id.RoomID, error) {
 				user.MXID:                 50,
 			},
 		},
-		Invite:   []id.UserID{user.MXID},
-		IsDirect: true,
+		BeeperLocalRoomID: id.RoomID(fmt.Sprintf("!management:%s", user.Bridge.Matrix.ServerName())),
+		Invite:            []id.UserID{user.MXID},
+		IsDirect:          true,
 	}
 	if autoJoin {
 		req.BeeperInitialMembers = []id.UserID{user.MXID}


### PR DESCRIPTION
How do we determine the management room id for local bridges? Would we be allowed to set it to empty like `!:server.name` and special case that or can we reserve a name?