### PR TITLE
Add matrix 1.3 api feature to refresh access token

### DIFF
--- a/requests.go
+++ b/requests.go
@@ -75,7 +75,7 @@ type UserIdentifier struct {
 	Phone   string `json:"phone,omitempty"`
 }
 
-// ReqLogin is the JSON request for https://spec.matrix.org/v1.2/client-server-api/#post_matrixclientv3login
+// ReqLogin is the JSON request for https://spec.matrix.org/v1.3/client-server-api/#post_matrixclientv3login
 type ReqLogin struct {
 	Type                     AuthType       `json:"type"`
 	Identifier               UserIdentifier `json:"identifier"`
@@ -89,6 +89,11 @@ type ReqLogin struct {
 	StoreCredentials bool `json:"-"`
 	// Whether or not the returned .well-known data should update the homeserver URL in the Client
 	StoreHomeserverURL bool `json:"-"`
+}
+
+// ReqRefresh is the JSON request for https://spec.matrix.org/v1.3/client-server-api/#post_matrixclientv3refresh
+type ReqRefresh struct {
+	RefreshToken string `json:"refresh_token"`
 }
 
 type ReqUIAuthFallback struct {

--- a/responses.go
+++ b/responses.go
@@ -201,16 +201,25 @@ func (rlf *RespLoginFlows) HasFlow(flowType ...AuthType) bool {
 	return rlf.FirstFlowOfType(flowType...) != nil
 }
 
-// RespLogin is the JSON response for https://spec.matrix.org/v1.2/client-server-api/#post_matrixclientv3login
+// RespLogin is the JSON response for https://spec.matrix.org/v1.3/client-server-api/#post_matrixclientv3login
 type RespLogin struct {
-	AccessToken string           `json:"access_token"`
-	DeviceID    id.DeviceID      `json:"device_id"`
-	UserID      id.UserID        `json:"user_id"`
-	WellKnown   *ClientWellKnown `json:"well_known,omitempty"`
+	AccessToken  string           `json:"access_token"`
+	DeviceID     id.DeviceID      `json:"device_id"`
+	ExpiresInMS  int64            `json:"expires_in_ms,omitempty"`
+	RefreshToken string           `json:"refresh_token,omitempty"`
+	UserID       id.UserID        `json:"user_id"`
+	WellKnown    *ClientWellKnown `json:"well_known,omitempty"`
 }
 
 // RespLogout is the JSON response for https://spec.matrix.org/v1.2/client-server-api/#post_matrixclientv3logout
 type RespLogout struct{}
+
+// RespRefresh is the JSON response for https://spec.matrix.org/v1.3/client-server-api/#post_matrixclientv3refresh
+type RespRefresh struct {
+	AccessToken  string `json:"access_token"`
+	ExpiresInMS  int64  `json:"expires_in_ms,omitempty"`
+	RefreshToken string `json:"refresh_token,omitempty"`
+}
 
 // RespCreateRoom is the JSON response for https://spec.matrix.org/v1.2/client-server-api/#post_matrixclientv3createroom
 type RespCreateRoom struct {


### PR DESCRIPTION
* Refresh tokens are returned by the Matrix homeserver when ReqLogin.RefreshToken is set.
* Add new functions to client for Refresh() which uses a previously stored refresh token to update the existing access token once it expires.
* Implements a fudge factor on the expiry duration so we refresh well before the access token expires.
