### PR TITLE
verificationhelper/request: check txn ID is different before sending cancellations

### DIFF
--- a/crypto/verificationhelper/verificationhelper.go
+++ b/crypto/verificationhelper/verificationhelper.go
@@ -690,7 +690,7 @@ func (vh *VerificationHelper) onVerificationRequest(ctx context.Context, evt *ev
 		TheirSupportedMethods: verificationRequest.Methods,
 	}
 	for existingTxnID, existingTxn := range vh.activeTransactions {
-		if existingTxn.TheirUser == evt.Sender && existingTxn.TheirDevice == verificationRequest.FromDevice {
+		if existingTxn.TheirUser == evt.Sender && existingTxn.TheirDevice == verificationRequest.FromDevice && existingTxnID != verificationRequest.TransactionID {
 			vh.cancelVerificationTxn(ctx, existingTxn, event.VerificationCancelCodeUnexpectedMessage, "received multiple verification requests from the same device")
 			vh.cancelVerificationTxn(ctx, newTxn, event.VerificationCancelCodeUnexpectedMessage, "received multiple verification requests from the same device")
 			delete(vh.activeTransactions, existingTxnID)


### PR DESCRIPTION
This will allow it to fallthrought to the correct error which is that we
received a new verification request for the same transaction ID.

Signed-off-by: Sumner Evans <sumner.evans@automattic.com>
