### PR TITLE
crypto/verificationhelper: add cross-signing to SAS verification path

### DIFF
--- a/crypto/verificationhelper/sas.go
+++ b/crypto/verificationhelper/sas.go
@@ -666,6 +666,14 @@ func (vh *VerificationHelper) onVerificationMAC(ctx context.Context, txn Verific
 				vh.cancelVerificationTxn(ctx, txn, event.VerificationCancelCodeUser, "failed to update device trust state after verifying: %w", err)
 				return
 			}
+
+			// Cross-sign their device with the self-signing key
+			if vh.mach.CrossSigningKeys != nil {
+				err = vh.mach.SignOwnDevice(ctx, theirDevice)
+				if err != nil {
+					log.Err(err).Msg("failed to sign own device")
+				}
+			}
 		}
 	}
 	log.Info().Msg("All MACs verified")


### PR DESCRIPTION
When verifying a new device via SAS / emoji verification, we never cross-sign the new device, which thus never fully finishes verification.

I copied the relevant `SignOwnDevice()` call from the QR verification path, tested and confirmed it works. Review appreciated from our Go and encryption experts if this is the right way to do it.