### PR TITLE
Add mautrix.Client.KnockRoom

### DIFF
--- a/requests.go
+++ b/requests.go
@@ -156,6 +156,11 @@ type ReqJoinRoom struct {
 	ThirdPartySigned any      `json:"third_party_signed,omitempty"`
 }
 
+type ReqKnockRoom struct {
+	Via    []string `json:"-"`
+	Reason string   `json:"reason,omitempty"`
+}
+
 type ReqMutualRooms struct {
 	From string `json:"-"`
 }

--- a/responses.go
+++ b/responses.go
@@ -33,6 +33,11 @@ type RespJoinRoom struct {
 	RoomID id.RoomID `json:"room_id"`
 }
 
+// RespKnockRoom is the JSON response for https://spec.matrix.org/v1.13/client-server-api/#post_matrixclientv3knockroomidoralias
+type RespKnockRoom struct {
+	RoomID id.RoomID `json:"room_id"`
+}
+
 // RespLeaveRoom is the JSON response for https://spec.matrix.org/v1.2/client-server-api/#post_matrixclientv3roomsroomidleave
 type RespLeaveRoom struct{}
 


### PR DESCRIPTION
Adds the ability to knock on rooms.

`RespKnockRoom` may be unnecessary as it is the same body as `RespJoinRoom` however included for semantics.