### PR TITLE
Extend HTTP timeouts for getting the full key backup

### DIFF
--- a/client.go
+++ b/client.go
@@ -2181,7 +2181,17 @@ func (cli *Client) GetKeyBackup(ctx context.Context, version id.KeyBackupVersion
 	urlPath := cli.BuildURLWithQuery(ClientURLPath{"v3", "room_keys", "keys"}, map[string]string{
 		"version": string(version),
 	})
-	_, err = cli.MakeRequest(ctx, http.MethodGet, urlPath, nil, &resp)
+	_, err = cli.MakeFullRequest(ctx, FullRequest{
+		Method:       http.MethodGet,
+		URL:          urlPath,
+		ResponseJSON: &resp,
+		Client: &http.Client{
+			Timeout: 180 * time.Second,
+			Transport: &http.Transport{
+				ResponseHeaderTimeout: 180 * time.Second,
+			},
+		},
+	})
 	return
 }
 


### PR DESCRIPTION
The default is 30 seconds, and this is way too short for users with large key backups.