### PR TITLE
Require cross signing keys to be present to verify another device

### DIFF
--- a/crypto/verificationhelper/verificationhelper.go
+++ b/crypto/verificationhelper/verificationhelper.go
@@ -607,6 +607,11 @@ func (vh *VerificationHelper) onVerificationRequest(ctx context.Context, evt *ev
 		return
 	}
 
+	if vh.mach.CrossSigningKeys == nil {
+		log.Warn().Msg("Ignoring verification request as we don't have cross signing keys")
+		return
+	}
+
 	log = log.With().
 		Any("requested_methods", verificationRequest.Methods).
 		Stringer("transaction_id", verificationRequest.TransactionID).


### PR DESCRIPTION
Saw a case today where an unverified client was accepting a verification request when it didn't have any cross signing keys or wasn't even verified itself. We should just drop these like any other kind of verification request we shouldn't handle.