### PR TITLE
Add EditInsteadOfDelete option to bridge 

### DIFF
--- a/bridgev2/bridgeconfig/config.go
+++ b/bridgev2/bridgeconfig/config.go
@@ -71,6 +71,7 @@ type BridgeConfig struct {
 	TagOnlyOnCreate         bool             `yaml:"tag_only_on_create"`
 	OnlyBridgeTags          []event.RoomTag  `yaml:"only_bridge_tags"`
 	MuteOnlyOnCreate        bool             `yaml:"mute_only_on_create"`
+	EditInsteadOfDelete     bool             `yaml:"edit_instead_of_delete"`
 	OutgoingMessageReID     bool             `yaml:"outgoing_message_re_id"`
 	CleanupOnLogout         CleanupOnLogouts `yaml:"cleanup_on_logout"`
 	Relay                   RelayConfig      `yaml:"relay"`

--- a/bridgev2/bridgeconfig/upgrade.go
+++ b/bridgev2/bridgeconfig/upgrade.go
@@ -37,6 +37,7 @@ func doUpgrade(helper up.Helper) {
 	helper.Copy(up.Bool, "bridge", "tag_only_on_create")
 	helper.Copy(up.List, "bridge", "only_bridge_tags")
 	helper.Copy(up.Bool, "bridge", "mute_only_on_create")
+	helper.Copy(up.Bool, "bridge", "edit_instead_of_delete")
 	helper.Copy(up.Bool, "bridge", "cleanup_on_logout", "enabled")
 	helper.Copy(up.Str, "bridge", "cleanup_on_logout", "manual", "private")
 	helper.Copy(up.Str, "bridge", "cleanup_on_logout", "manual", "relayed")

--- a/bridgev2/matrix/mxmain/example-config.yaml
+++ b/bridgev2/matrix/mxmain/example-config.yaml
@@ -38,7 +38,8 @@ bridge:
     # Should room mute status only be synced when creating the portal?
     # Like tags, mutes can't currently be synced back to the remote network.
     mute_only_on_create: true
-
+    # Should the bridge send a `m.replace` instead of `m.room.redaction` event when a message is deleted?
+    edit_instead_of_delete: false
     # What should be done to portal rooms when a user logs out or is logged out?
     # Permitted values:
     #   nothing - Do nothing, let the user stay in the portals


### PR DESCRIPTION
If `bridge.edit_instead_of_delete` set to true, the bride will edit the message that should be deleted to "This message has been deleted." instead of sending a `m.room.redaction` event.