### PR TITLE
Backport msc4190 from bridgev2

### DIFF
--- a/appservice/registration.go
+++ b/appservice/registration.go
@@ -29,6 +29,7 @@ type Registration struct {
 
 	SoruEphemeralEvents bool `yaml:"de.sorunome.msc2409.push_ephemeral,omitempty" json:"de.sorunome.msc2409.push_ephemeral,omitempty"`
 	EphemeralEvents     bool `yaml:"push_ephemeral,omitempty" json:"push_ephemeral,omitempty"`
+	MSC4190             bool `yaml:"io.element.msc4190,omitempty" json:"io.element.msc4190,omitempty"`
 }
 
 // CreateRegistration creates a Registration with random appservice and homeserver tokens.

--- a/bridge/bridgeconfig/config.go
+++ b/bridge/bridgeconfig/config.go
@@ -97,6 +97,8 @@ func (config *BaseConfig) GenerateRegistration() *appservice.Registration {
 	registration.Namespaces.UserIDs.Register(botRegex, true)
 	registration.Namespaces.UserIDs.Register(config.MakeUserIDRegex(".*"), true)
 
+	config.Bridge.GetEncryptionConfig().applyUnstableFlags(registration)
+
 	return registration
 }
 
@@ -108,6 +110,7 @@ func (config *BaseConfig) MakeAppService() *appservice.AppService {
 	as.Host.Port = config.AppService.Port
 	as.DefaultHTTPRetries = 4
 	as.Registration = config.AppService.GetRegistration()
+	config.Bridge.GetEncryptionConfig().applyUnstableFlags(as.Registration)
 	return as
 }
 
@@ -120,6 +123,10 @@ func (asc *AppserviceConfig) GetRegistration() *appservice.Registration {
 	reg.ServerToken = asc.HSToken
 	reg.AppToken = asc.ASToken
 	return reg
+}
+
+func (ec EncryptionConfig) applyUnstableFlags(registration *appservice.Registration) {
+	registration.MSC4190 = ec.MSC4190
 }
 
 func (asc *AppserviceConfig) copyToRegistration(registration *appservice.Registration) {
@@ -180,6 +187,7 @@ type EncryptionConfig struct {
 	Default    bool `yaml:"default"`
 	Require    bool `yaml:"require"`
 	Appservice bool `yaml:"appservice"`
+	MSC4190    bool `yaml:"msc4190"`
 
 	PlaintextMentions bool `yaml:"plaintext_mentions"`
 

--- a/crypto/cryptohelper/cryptohelper.go
+++ b/crypto/cryptohelper/cryptohelper.go
@@ -58,7 +58,7 @@ func NewCryptoHelper(cli *mautrix.Client, pickleKey []byte, store any) (*CryptoH
 		return nil, fmt.Errorf("pickle key must be provided")
 	}
 	_, isExtensible := cli.Syncer.(mautrix.ExtensibleSyncer)
-	if !isExtensible {
+	if !cli.SetAppServiceDeviceID && !isExtensible {
 		return nil, fmt.Errorf("the client syncer must implement ExtensibleSyncer")
 	}
 

--- a/requests.go
+++ b/requests.go
@@ -89,6 +89,10 @@ type ReqLogin struct {
 	StoreHomeserverURL bool `json:"-"`
 }
 
+type ReqPutDevice struct {
+	DisplayName string `json:"display_name,omitempty"`
+}
+
 type ReqUIAuthFallback struct {
 	Session string `json:"session"`
 	User    string `json:"user"`

--- a/url.go
+++ b/url.go
@@ -102,6 +102,10 @@ func (cli *Client) BuildURLWithQuery(urlPath PrefixableURLPath, urlQuery map[str
 	if cli.SetAppServiceUserID {
 		query.Set("user_id", string(cli.UserID))
 	}
+	if cli.SetAppServiceDeviceID && cli.DeviceID != "" {
+		query.Set("device_id", string(cli.DeviceID))
+		query.Set("org.matrix.msc3202.device_id", string(cli.DeviceID))
+	}
 	if urlQuery != nil {
 		for k, v := range urlQuery {
 			query.Set(k, v)


### PR DESCRIPTION
I've attempted to backport the [msc4190 support](https://github.com/mautrix/go/pull/288) form bridgev2.

The main reason for this is to allow mautrix-discord to use msc4190 before the bridgev2 rewrite.

~~I think this should work, but I'm unsure how to test this.~~

~~From what I undestand~~ The (encryption) config upgrade needs to be done in the bridge itself instead of here.
Draft [PR to mautrix-discord](https://github.com/mautrix/discord/pull/181) 