### PR TITLE
bridgev2: always update avatar if MXC changes

### DIFF
--- a/bridgev2/ghost.go
+++ b/bridgev2/ghost.go
@@ -162,7 +162,7 @@ func (ghost *Ghost) UpdateAvatar(ctx context.Context, avatar *Avatar) bool {
 			ghost.AvatarSet = false
 			zerolog.Ctx(ctx).Err(err).Msg("Failed to reupload avatar")
 			return true
-		} else if newHash == ghost.AvatarHash && ghost.AvatarSet {
+		} else if newMXC == ghost.AvatarMXC && newHash == ghost.AvatarHash && ghost.AvatarSet {
 			return true
 		}
 		ghost.AvatarHash = newHash

--- a/bridgev2/portal.go
+++ b/bridgev2/portal.go
@@ -3041,7 +3041,7 @@ func (portal *Portal) updateAvatar(ctx context.Context, avatar *Avatar, sender M
 			portal.AvatarSet = false
 			zerolog.Ctx(ctx).Err(err).Msg("Failed to reupload room avatar")
 			return true
-		} else if newHash == portal.AvatarHash && portal.AvatarSet {
+		} else if newMXC == portal.AvatarMXC && newHash == portal.AvatarHash && portal.AvatarSet {
 			return true
 		}
 		portal.AvatarMXC = newMXC


### PR DESCRIPTION
When using direct downloads only the MXC changes but hash stays empty.