### PR TITLE
client: don't attempt to make requests if the homeserver URL isn't set

### DIFF
--- a/client.go
+++ b/client.go
@@ -481,6 +481,9 @@ func (cli *Client) MakeFullRequestWithResp(ctx context.Context, params FullReque
 	if cli == nil {
 		return nil, nil, ErrClientIsNil
 	}
+	if cli.HomeserverURL == nil || cli.HomeserverURL.Scheme == "" {
+		return nil, nil, ErrClientHasNoHomeserver
+	}
 	if params.MaxAttempts == 0 {
 		maxAttempts, ok := ctx.Value(MaxAttemptsContextKey).(int)
 		if ok && maxAttempts > 0 {

--- a/error.go
+++ b/error.go
@@ -77,7 +77,8 @@ var (
 )
 
 var (
-	ErrClientIsNil = errors.New("client is nil")
+	ErrClientIsNil           = errors.New("client is nil")
+	ErrClientHasNoHomeserver = errors.New("client has no homeserver set")
 )
 
 // HTTPError An HTTP Error response, which may wrap an underlying native Go Error.


### PR DESCRIPTION
Quick guard for where the client is created without using the `NewClient` method.