### PR TITLE
bridgev2: add shared event handling context

### DIFF
--- a/bridgev2/portal.go
+++ b/bridgev2/portal.go
@@ -375,7 +375,7 @@ func (portal *Portal) getEventCtxWithLog(rawEvt any, idx int) context.Context {
 	case *portalCreateEvent:
 		return evt.ctx
 	}
-	return logWith.Logger().WithContext(context.Background())
+	return logWith.Logger().WithContext(portal.Bridge.backgroundCtx)
 }
 
 func (portal *Portal) handleSingleEvent(ctx context.Context, rawEvt any, doneCallback func()) {


### PR DESCRIPTION
This context is then passed into the network connectors handlers and message conversion functions which may require making network requests, which before this would not be canceled on bridge stop.