### PR TITLE
bridgev2: Configurable disconnect timeout

### DIFF
--- a/bridgev2/matrix/mxmain/main.go
+++ b/bridgev2/matrix/mxmain/main.go
@@ -421,7 +421,7 @@ func (br *BridgeMain) TriggerStop(exitCode int) {
 
 // Stop cleanly stops the bridge. This is called by [Run] and does not need to be called manually.
 func (br *BridgeMain) Stop() {
-	br.Bridge.Stop()
+	br.Bridge.StopWithTimeout(5 * time.Second)
 }
 
 // InitVersion formats the bridge version and build time nicely for things like


### PR DESCRIPTION
Let the caller decide if they want to have a timeout or not.  For
standalone bridges using the Bridge struct the behavior is kept the same
by waiting for five seconds when UserLogin DisconnectWithTimeout() is
called.