### PR TITLE
event: add join_authorised_via_users_server to MemberEventContent

### DIFF
--- a/event/member.go
+++ b/event/member.go
@@ -41,7 +41,7 @@ type MemberEventContent struct {
 	IsDirect                     bool                `json:"is_direct,omitempty"`
 	ThirdPartyInvite             *ThirdPartyInvite   `json:"third_party_invite,omitempty"`
 	Reason                       string              `json:"reason,omitempty"`
-	JoinAuthorisedViaUsersServer *id.UserID          `json:"join_authorised_via_users_server,omitempty"`
+	JoinAuthorisedViaUsersServer id.UserID           `json:"join_authorised_via_users_server,omitempty"`
 	MSC3414File                  *EncryptedFileInfo  `json:"org.matrix.msc3414.file,omitempty"`
 
 	MSC4293RedactEvents bool `json:"org.matrix.msc4293.redact_events,omitempty"`

--- a/event/member.go
+++ b/event/member.go
@@ -35,13 +35,14 @@ const (
 // MemberEventContent represents the content of a m.room.member state event.
 // https://spec.matrix.org/v1.2/client-server-api/#mroommember
 type MemberEventContent struct {
-	Membership       Membership          `json:"membership"`
-	AvatarURL        id.ContentURIString `json:"avatar_url,omitempty"`
-	Displayname      string              `json:"displayname,omitempty"`
-	IsDirect         bool                `json:"is_direct,omitempty"`
-	ThirdPartyInvite *ThirdPartyInvite   `json:"third_party_invite,omitempty"`
-	Reason           string              `json:"reason,omitempty"`
-	MSC3414File      *EncryptedFileInfo  `json:"org.matrix.msc3414.file,omitempty"`
+	Membership                   Membership          `json:"membership"`
+	AvatarURL                    id.ContentURIString `json:"avatar_url,omitempty"`
+	Displayname                  string              `json:"displayname,omitempty"`
+	IsDirect                     bool                `json:"is_direct,omitempty"`
+	ThirdPartyInvite             *ThirdPartyInvite   `json:"third_party_invite,omitempty"`
+	Reason                       string              `json:"reason,omitempty"`
+	JoinAuthorisedViaUsersServer *id.UserID          `json:"join_authorised_via_users_server,omitempty"`
+	MSC3414File                  *EncryptedFileInfo  `json:"org.matrix.msc3414.file,omitempty"`
 
 	MSC4293RedactEvents bool `json:"org.matrix.msc4293.redact_events,omitempty"`
 }


### PR DESCRIPTION
Adds `JoinAuthorisedViaUsersServer` (`join_authorised_via_users_server`) to `MemberEventContent`, introduced in room version 8