### PR TITLE
pdu/auth: Add JSON marshaling support to StateKey

### DIFF
--- a/federation/pdu/auth.go
+++ b/federation/pdu/auth.go
@@ -25,7 +25,7 @@ type StateKey struct {
 }
 
 func (sk StateKey) MarshalJSON() ([]byte, error) {
-	return []byte(fmt.Sprintf('"%s/%s"', sk.Type, sk.StateKey)), nil
+	return []byte(fmt.Sprintf("\"%s/%s\"", sk.Type, sk.StateKey)), nil
 }
 
 var thirdPartyInviteTokenPath = exgjson.Path("third_party_invite", "signed", "token")


### PR DESCRIPTION
This was causing issues for me since logging a map of `map[pdu.StateKey]*pdu.PDU` would give me marshalling errors since statekey can't be marshalled despite just being  (type,key) tuple