### PR TITLE
error: Add RespError WithExtraData convenience function

### DIFF
--- a/error.go
+++ b/error.go
@@ -177,6 +177,12 @@ func (e RespError) WithStatus(status int) RespError {
 	return e
 }
 
+func (e RespError) WithExtraData(extraData map[string]any) RespError {
+	e.ExtraData = maps.Clone(e.ExtraData)
+	maps.Copy(e.ExtraData, extraData)
+	return e
+}
+
 // Error returns the errcode and error message.
 func (e RespError) Error() string {
 	return e.ErrCode + ": " + e.Err


### PR DESCRIPTION
To dynamically build errors with extra keys like returning `max_delay` for `M_MAX_DELAY_EXCEEDED`.