### PR TITLE
synapseadmin: Add force_purge option

### DIFF
--- a/synapseadmin/roomapi.go
+++ b/synapseadmin/roomapi.go
@@ -117,6 +117,7 @@ func (cli *Client) RoomMessages(ctx context.Context, roomID id.RoomID, from, to 
 
 type ReqDeleteRoom struct {
 	Purge         bool      `json:"purge,omitempty"`
+	ForcePurge    bool      `json:"force_purge,omitempty"`
 	Block         bool      `json:"block,omitempty"`
 	Message       string    `json:"message,omitempty"`
 	RoomName      string    `json:"room_name,omitempty"`


### PR DESCRIPTION
Adds the `force_purge` request option to the room delete function to allow forcing a purge, even if local users remain in the room.