### PR TITLE
client: Implement MSC4034 bodies and endpoint

### DIFF
--- a/client.go
+++ b/client.go
@@ -2729,6 +2729,13 @@ func (cli *Client) UnstableSetLockStatus(ctx context.Context, userID id.UserID, 
 	return
 }
 
+// UnstableGetStorageUsage queries MSC4034 storage usage information for the current account.
+func (cli *Client) UnstableGetStorageUsage(ctx context.Context) (resp *RespStorageUsage, err error) {
+	urlPath := cli.BuildClientURL("unstable", "org.matrix.msc4034", "usage")
+	_, err = cli.MakeRequest(ctx, http.MethodGet, urlPath, nil, &resp)
+	return
+}
+
 func (cli *Client) AppservicePing(ctx context.Context, id, txnID string) (resp *RespAppservicePing, err error) {
 	_, err = cli.MakeFullRequest(ctx, FullRequest{
 		Method:       http.MethodPost,

--- a/responses.go
+++ b/responses.go
@@ -132,7 +132,15 @@ type RespRedactUserEvents struct {
 
 // RespMediaConfig is the JSON response for https://spec.matrix.org/v1.4/client-server-api/#get_matrixmediav3config
 type RespMediaConfig struct {
-	UploadSize int64 `json:"m.upload.size,omitempty"`
+	UploadSize           int64  `json:"m.upload.size,omitempty"`
+	UnstableStorageSize  *int64 `json:"org.matrix.msc4034.storage.size,omitempty"`
+	UnstableStorageFiles *int64 `json:"org.matrix.msc4034.storage.max_files,omitempty"`
+}
+
+// RespStorageUsage is the JSON response for https://github.com/matrix-org/matrix-spec-proposals/pull/4034
+type RespStorageUsage struct {
+	Used  *int64 `json:"org.matrix.msc4034.storage.used,omitempty"`
+	Files *int64 `json:"org.matrix.msc4034.storage.files,omitempty"`
 }
 
 // RespMediaUpload is the JSON response for https://spec.matrix.org/v1.2/client-server-api/#post_matrixmediav3upload


### PR DESCRIPTION
This PR adds the new fields for `/_matrix/media/v3/config` (and the auth equiv), and also implements the request & response for the usage endpoint introduced by https://github.com/matrix-org/matrix-spec-proposals/pull/4034
