### PR TITLE
make an empty JoinRules map when creating a new MemoryStateStore

### DIFF
--- a/statestore.go
+++ b/statestore.go
@@ -129,6 +129,7 @@ func NewMemoryStateStore() StateStore {
 		PowerLevels:    make(map[id.RoomID]*event.PowerLevelsEventContent),
 		Encryption:     make(map[id.RoomID]*event.EncryptionEventContent),
 		Create:         make(map[id.RoomID]*event.Event),
+		JoinRules:      make(map[id.RoomID]*event.JoinRulesEventContent),
 	}
 }
 


### PR DESCRIPTION
<!-- Make sure you read the contributing guidelines first:
https://docs.mau.fi/bridges/general/contributing.html -->

I started seeing crashes after updating to the latest version of this library, it looks like e31d186dc8d3813b171564404cf3e7859d800748 introduced a new map to `MemoryStateStore` but doesn't initialized it in `NewMemoryStateStore()`