### PR TITLE
client: add special error that indicates to retry canceled contexts

### DIFF
--- a/error.go
+++ b/error.go
@@ -85,6 +85,10 @@ var (
 
 	ErrResponseTooLong      = errors.New("response content length too long")
 	ErrBodyReadReachedLimit = errors.New("reached response size limit while reading body")
+
+	// Special error that indicates we should retry canceled contexts. Note that on it's own this
+	// is useless, the context itself must also be replaced.
+	ErrContextCancelRetry = errors.New("retry canceled context")
 )
 
 // HTTPError An HTTP Error response, which may wrap an underlying native Go Error.


### PR DESCRIPTION
On it's own this is useless since the retries would all immediately fail with the canceled context error. The caller is expected to also set a `UpdateRequestOnRetry` on the client which is used to swap out the context.


This could well be a terrible idea.