### PR TITLE
verification: Clean up logging when checking transaction IDs

### DIFF
--- a/crypto/verificationhelper/verificationhelper.go
+++ b/crypto/verificationhelper/verificationhelper.go
@@ -236,7 +236,8 @@ func (vh *VerificationHelper) Init(ctx context.Context) error {
 
 			logCtx := vh.getLog(ctx).With().
 				Stringer("transaction_step", txn.VerificationState).
-				Stringer("sender", evt.Sender)
+				Stringer("sender", evt.Sender).
+				Stringer("event_type", evt.Type)
 			if evt.RoomID != "" {
 				logCtx = logCtx.
 					Stringer("room_id", evt.RoomID).


### PR DESCRIPTION
The `wrapHandler` was nesting contexts, so when adding the `verification_action=check transaction ID` portion it reused that same context when calling the supplied callback, which then added a new set of parameters and duplicated `verification_action` and others.

Also refactor checkTransactionID into it's own function so it's easier to read as it's own step, make it clear we throw away that derived context with the fields, and take advantage of `defer` for unlocking.