### PR TITLE
crypto,bridgev2: add option to encrypt reactions and replies

### DIFF
--- a/bridgev2/bridgeconfig/encryption.go
+++ b/bridgev2/bridgeconfig/encryption.go
@@ -16,6 +16,7 @@ type EncryptionConfig struct {
 	Require    bool `yaml:"require"`
 	Appservice bool `yaml:"appservice"`
 	MSC4190    bool `yaml:"msc4190"`
+	MSC4392    bool `yaml:"msc4392"`
 	SelfSign   bool `yaml:"self_sign"`
 
 	PlaintextMentions bool `yaml:"plaintext_mentions"`

--- a/bridgev2/bridgeconfig/upgrade.go
+++ b/bridgev2/bridgeconfig/upgrade.go
@@ -161,6 +161,7 @@ func doUpgrade(helper up.Helper) {
 	} else {
 		helper.Copy(up.Bool, "encryption", "msc4190")
 	}
+	helper.Copy(up.Bool, "encryption", "msc4392")
 	helper.Copy(up.Bool, "encryption", "self_sign")
 	helper.Copy(up.Bool, "encryption", "allow_key_sharing")
 	if secret, ok := helper.Get(up.Str, "encryption", "pickle_key"); !ok || secret == "generate" {

--- a/bridgev2/matrix/intent.go
+++ b/bridgev2/matrix/intent.go
@@ -56,7 +56,7 @@ func (as *ASIntent) SendMessage(ctx context.Context, roomID id.RoomID, eventType
 			Extra:  content.Raw,
 		})
 	}
-	if eventType != event.EventReaction && eventType != event.EventRedaction {
+	if (eventType != event.EventReaction || as.Connector.Config.Encryption.MSC4392) && eventType != event.EventRedaction {
 		msgContent, ok := content.Parsed.(*event.MessageEventContent)
 		if ok {
 			msgContent.AddPerMessageProfileFallback()

--- a/bridgev2/matrix/mxmain/example-config.yaml
+++ b/bridgev2/matrix/mxmain/example-config.yaml
@@ -378,6 +378,8 @@ encryption:
     # Only relevant when using end-to-bridge encryption, required when using encryption with next-gen auth (MSC3861).
     # Changing this option requires updating the appservice registration file.
     msc4190: false
+    # Whether to encrypt reactions and reply metadata as per MSC4392.
+    msc4392: false
     # Should the bridge bot generate a recovery key and cross-signing keys and verify itself?
     # Note that without the latest version of MSC4190, this will fail if you reset the bridge database.
     # The generated recovery key will be saved in the kv_store table under `recovery_key`.

--- a/crypto/encryptmegolm.go
+++ b/crypto/encryptmegolm.go
@@ -169,6 +169,15 @@ func (mach *OlmMachine) EncryptMegolmEventWithStateKey(ctx context.Context, room
 		SenderKey: mach.account.IdentityKey(),
 		DeviceID:  mach.Client.DeviceID,
 	}
+	if mach.MSC4392Relations && encrypted.RelatesTo != nil {
+		// When MSC4392 mode is enabled, reply and reaction metadata is stripped from the unencrypted content.
+		// Other relations like threads are still left unencrypted.
+		encrypted.RelatesTo.InReplyTo = nil
+		encrypted.RelatesTo.IsFallingBack = false
+		if evtType == event.EventReaction || encrypted.RelatesTo.Type == "" {
+			encrypted.RelatesTo = nil
+		}
+	}
 	if mach.PlaintextMentions {
 		encrypted.Mentions = getMentions(content)
 	}

--- a/crypto/machine.go
+++ b/crypto/machine.go
@@ -39,6 +39,7 @@ type OlmMachine struct {
 	cancelBackgroundCtx context.CancelFunc
 
 	PlaintextMentions   bool
+	MSC4392Relations    bool
 	AllowEncryptedState bool
 
 	// Never ask the server for keys automatically as a side effect during Megolm decryption.


### PR DESCRIPTION
As per https://github.com/matrix-org/matrix-spec-proposals/pull/4392

Decryption is already compatible with encrypted `m.relates_to`