### PR TITLE
bridgev2/userlogin: copy the remote profile when filling bridge state

### DIFF
--- a/bridgev2/userlogin.go
+++ b/bridgev2/userlogin.go
@@ -512,7 +512,8 @@ func (ul *UserLogin) FillBridgeState(state status.BridgeState) status.BridgeStat
 	state.UserID = ul.UserMXID
 	state.RemoteID = ul.ID
 	state.RemoteName = ul.RemoteName
-	state.RemoteProfile = &ul.RemoteProfile
+	profileCopy := ul.RemoteProfile
+	state.RemoteProfile = &profileCopy
 	filler, ok := ul.Client.(status.BridgeStateFiller)
 	if ok {
 		return filler.FillBridgeState(state)


### PR DESCRIPTION
Here's the relevant line:

https://github.com/mautrix/go/blob/7836f35a1a7431a3eb7f1a09697d324058dbde01/bridgev2/userlogin.go#L515

By pointing into `ul.RemoteProfile` directly, the "pending" `BridgeState` will always point to the "latest" `RemoteProfile`, which leads the `RemoteProfile` comparison in `ShouldDeduplicate` to always think that the `RemoteProfile` hasn't changed:

https://github.com/mautrix/go/blob/7836f35a1a7431a3eb7f1a09697d324058dbde01/bridgev2/status/bridgestate.go#L208-L213

I think it's always going to dereference the same two pointers; i.e. it does `*ul.RemoteProfile == *ul.RemoteProfile` which would always be `true`.

We can make a copy instead, which will do a shallow snapshot of sorts:

```go
	profileCopy := ul.RemoteProfile
	state.RemoteProfile = &profileCopy
```

It wouldn't be resilient to in-place `AvatarFile` mutations that don't take care to replace the entire value, but that seems okay?

<!-- Make sure you read the contributing guidelines first:
https://docs.mau.fi/bridges/general/contributing.html -->
