### PR TITLE
client: support MSC4446 for moving `m.fully_read` backwards

### DIFF
--- a/requests.go
+++ b/requests.go
@@ -425,6 +425,8 @@ type ReqSetReadMarkers struct {
 	Read        id.EventID `json:"m.read,omitempty"`
 	ReadPrivate id.EventID `json:"m.read.private,omitempty"`
 	FullyRead   id.EventID `json:"m.fully_read,omitempty"`
+	// Allow moving m.fully_read backwards via MSC4446.
+	AllowBackward bool `json:"com.beeper.allow_backward,omitempty"`
 
 	BeeperReadExtra        interface{} `json:"com.beeper.read.extra,omitempty"`
 	BeeperReadPrivateExtra interface{} `json:"com.beeper.read.private.extra,omitempty"`
@@ -444,6 +446,8 @@ type ReqSetBeeperInboxState struct {
 
 type ReqSendReceipt struct {
 	ThreadID string `json:"thread_id,omitempty"`
+	// Allow moving m.fully_read backwards via MSC4446.
+	AllowBackward bool `json:"com.beeper.allow_backward,omitempty"`
 }
 
 type ReqPublicRooms struct {

--- a/versions.go
+++ b/versions.go
@@ -74,6 +74,7 @@ var (
 	FeatureRedactSendAsEvent         = UnstableFeature{UnstableFlag: "com.beeper.msc4169"}
 	FeatureUnstableReplaceProfile    = UnstableFeature{UnstableFlag: "com.beeper.msc4437"}
 	FeatureStableReplaceProfile      = UnstableFeature{UnstableFlag: "com.beeper.msc4437.stable"}
+	FeatureFullyReadBackward         = UnstableFeature{UnstableFlag: "com.beeper.msc4446"}
 
 	BeeperFeatureHungry                = UnstableFeature{UnstableFlag: "com.beeper.hungry"}
 	BeeperFeatureBatchSending          = UnstableFeature{UnstableFlag: "com.beeper.batch_sending"}

--- a/versions_test.go
+++ b/versions_test.go
@@ -32,7 +32,6 @@ const sampleVersions = `{
     "org.matrix.label_based_filtering": true,
     "org.matrix.e2e_cross_signing": true,
     "org.matrix.msc2432": true,
-    "com.beeper.msc4446": true,
     "uk.half-shot.msc2666.mutual_rooms": true,
     "io.element.e2ee_forced.public": false,
     "io.element.e2ee_forced.private": false,
@@ -53,7 +52,6 @@ func TestRespVersions_UnmarshalJSON(t *testing.T) {
 	assert.True(t, resp.ContainsGreaterOrEqual(mautrix.SpecV11))
 	assert.True(t, resp.Contains(mautrix.SpecV12))
 	assert.True(t, resp.Contains(mautrix.SpecR061))
-	assert.True(t, resp.Supports(mautrix.FeatureFullyReadBackward))
 	assert.True(t, resp.ContainsGreaterOrEqual(mautrix.MustParseSpecVersion("r0.0.0")))
 	assert.True(t, !resp.ContainsGreaterOrEqual(mautrix.MustParseSpecVersion("v123.456")))
 }

--- a/versions_test.go
+++ b/versions_test.go
@@ -32,6 +32,7 @@ const sampleVersions = `{
     "org.matrix.label_based_filtering": true,
     "org.matrix.e2e_cross_signing": true,
     "org.matrix.msc2432": true,
+    "com.beeper.msc4446": true,
     "uk.half-shot.msc2666.mutual_rooms": true,
     "io.element.e2ee_forced.public": false,
     "io.element.e2ee_forced.private": false,
@@ -52,6 +53,7 @@ func TestRespVersions_UnmarshalJSON(t *testing.T) {
 	assert.True(t, resp.ContainsGreaterOrEqual(mautrix.SpecV11))
 	assert.True(t, resp.Contains(mautrix.SpecV12))
 	assert.True(t, resp.Contains(mautrix.SpecR061))
+	assert.True(t, resp.Supports(mautrix.FeatureFullyReadBackward))
 	assert.True(t, resp.ContainsGreaterOrEqual(mautrix.MustParseSpecVersion("r0.0.0")))
 	assert.True(t, !resp.ContainsGreaterOrEqual(mautrix.MustParseSpecVersion("v123.456")))
 }


### PR DESCRIPTION
https://github.com/matrix-org/matrix-spec-proposals/pull/4446

### Checklist

* [x] I have read and followed the contributing guidelines at <https://docs.mau.fi/bridges/general/contributing.html>
