### PR TITLE
bridgev2/matrix: Propagate start errors to caller

### DIFF
--- a/appservice/ping.go
+++ b/appservice/ping.go
@@ -10,7 +10,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"os"
 	"strings"
 	"time"
 
@@ -19,7 +18,7 @@ import (
 	"maunium.net/go/mautrix"
 )
 
-func (intent *IntentAPI) EnsureAppserviceConnection(ctx context.Context) {
+func (intent *IntentAPI) EnsureAppserviceConnection(ctx context.Context) bool {
 	var pingResp *mautrix.RespAppservicePing
 	var txnID string
 	var retryCount int
@@ -55,7 +54,7 @@ func (intent *IntentAPI) EnsureAppserviceConnection(ctx context.Context) {
 		if outOfRetries {
 			evt.Msg("Homeserver -> appservice connection is not working")
 			zerolog.Ctx(ctx).Info().Msg("See https://docs.mau.fi/faq/as-ping for more info")
-			os.Exit(13)
+			return false
 		}
 		evt.Msg("Homeserver -> appservice connection is not working, retrying in 5 seconds...")
 		time.Sleep(5 * time.Second)
@@ -65,4 +64,5 @@ func (intent *IntentAPI) EnsureAppserviceConnection(ctx context.Context) {
 		Str("txn_id", txnID).
 		Int64("duration_ms", pingResp.DurationMS).
 		Msg("Homeserver -> appservice connection works")
+	return true
 }

--- a/bridgev2/matrix/connector.go
+++ b/bridgev2/matrix/connector.go
@@ -14,7 +14,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
-	"os"
 	"regexp"
 	"strings"
 	"sync"
@@ -212,11 +211,13 @@ func (br *Connector) Start(ctx context.Context) error {
 		go br.AS.Start()
 	} else {
 		br.Log.WithLevel(zerolog.FatalLevel).Msg("Neither appservice HTTP listener nor websocket is enabled")
-		os.Exit(23)
+		return ExitError{23}
 	}
 
 	br.Log.Debug().Msg("Checking connection to homeserver")
-	br.ensureConnection(ctx)
+	if err := br.ensureConnection(ctx); err != nil {
+		return err
+	}
 	go br.fetchMediaConfig(ctx)
 	if br.Crypto != nil {
 		err = br.Crypto.Init(ctx)
@@ -355,7 +356,7 @@ func (br *Connector) logInitialRequestError(err error, defaultMessage string) {
 	}
 }
 
-func (br *Connector) ensureConnection(ctx context.Context) {
+func (br *Connector) ensureConnection(ctx context.Context) error {
 	triedToRegister := false
 	for {
 		versions, err := br.Bot.Versions(ctx)
@@ -365,15 +366,22 @@ func (br *Connector) ensureConnection(ctx context.Context) {
 				err = br.Bot.EnsureRegistered(ctx)
 				if err != nil {
 					br.logInitialRequestError(err, "Failed to register after /versions failed with M_FORBIDDEN")
-					os.Exit(16)
+					return fmt.Errorf("%w: failed to register after /versions failed with M_FORBIDDEN: %w", ExitError{16}, err)
 				}
 				triedToRegister = true
 			} else if errors.Is(err, mautrix.MUnknownToken) || errors.Is(err, mautrix.MExclusive) {
 				br.logInitialRequestError(err, "/versions request failed with auth error")
-				os.Exit(16)
+				return fmt.Errorf("%w: /versions request failed with auth error: %w", ExitError{16}, err)
+			} else if errors.Is(err, context.Canceled) {
+				br.logInitialRequestError(err, "/versions request was canceled")
+				return fmt.Errorf("%w: /versions request was canceled: %w", ExitError{16}, err)
 			} else {
 				br.Log.Err(err).Msg("Failed to connect to homeserver, retrying in 10 seconds...")
-				time.Sleep(10 * time.Second)
+				select {
+				case <-time.After(10 * time.Second):
+				case <-ctx.Done():
+					return fmt.Errorf("%w: %w", ExitError{16}, ctx.Err())
+				}
 			}
 		} else {
 			br.SpecVersions = versions
@@ -395,38 +403,37 @@ func (br *Connector) ensureConnection(ctx context.Context) {
 	}
 	if br.Config.Homeserver.Software == bridgeconfig.SoftwareHungry && !br.SpecVersions.Supports(mautrix.BeeperFeatureHungry) {
 		br.Log.WithLevel(zerolog.FatalLevel).Msg("The config claims the homeserver is hungryserv, but the /versions response didn't confirm it")
-		os.Exit(18)
+		return ExitError{18}
 	} else if !br.SpecVersions.ContainsGreaterOrEqual(MinSpecVersion) {
 		br.Log.WithLevel(unsupportedServerLogLevel).
 			Stringer("server_supports", br.SpecVersions.GetLatest()).
 			Stringer("bridge_requires", MinSpecVersion).
 			Msg("The homeserver is outdated (supported spec versions are below minimum required by bridge)")
 		if !br.IgnoreUnsupportedServer {
-			os.Exit(18)
+			return ExitError{18}
 		}
 	}
 
 	resp, err := br.Bot.Whoami(ctx)
 	if err != nil {
 		br.logInitialRequestError(err, "/whoami request failed with unknown error")
-		os.Exit(16)
+		return fmt.Errorf("%w: /whoami request failed with unknown error: %w", ExitError{16}, err)
 	} else if resp.UserID != br.Bot.UserID {
 		br.Log.WithLevel(zerolog.FatalLevel).
 			Stringer("got_user_id", resp.UserID).
 			Stringer("expected_user_id", br.Bot.UserID).
 			Msg("Unexpected user ID in whoami call")
-		os.Exit(17)
+		return ExitError{17}
 	}
 
 	if br.Websocket {
 		br.Log.Debug().Msg("Websocket mode: no need to check status of homeserver -> bridge connection")
-		return
 	} else if !br.SpecVersions.Supports(mautrix.FeatureAppservicePing) {
 		br.Log.Debug().Msg("Homeserver does not support checking status of homeserver -> bridge connection")
-		return
+	} else if !br.Bot.EnsureAppserviceConnection(ctx) {
+		return ExitError{13}
 	}
-
-	br.Bot.EnsureAppserviceConnection(ctx)
+	return nil
 }
 
 func (br *Connector) fetchCapabilities(ctx context.Context) *mautrix.RespCapabilities {

--- a/bridgev2/matrix/crypto.go
+++ b/bridgev2/matrix/crypto.go
@@ -143,7 +143,9 @@ func (helper *CryptoHelper) Init(ctx context.Context) error {
 		return err
 	}
 	if isExistingDevice {
-		if !helper.verifyKeysAreOnServer(ctx) {
+		if ok, err := helper.verifyKeysAreOnServer(ctx); err != nil {
+			return err
+		} else if !ok {
 			return nil
 		}
 	} else {
@@ -154,7 +156,7 @@ func (helper *CryptoHelper) Init(ctx context.Context) error {
 	}
 	if helper.bridge.Config.Encryption.SelfSign {
 		if !helper.doSelfSign(ctx) {
-			os.Exit(34)
+			return ExitError{34}
 		}
 	}
 
@@ -334,7 +336,7 @@ func (helper *CryptoHelper) loginBot(ctx context.Context) (*mautrix.Client, bool
 	return client, deviceID != "", nil
 }
 
-func (helper *CryptoHelper) verifyKeysAreOnServer(ctx context.Context) bool {
+func (helper *CryptoHelper) verifyKeysAreOnServer(ctx context.Context) (bool, error) {
 	helper.log.Debug().Msg("Making sure keys are still on server")
 	resp, err := helper.client.QueryKeys(ctx, &mautrix.ReqQueryKeys{
 		DeviceKeys: map[id.UserID]mautrix.DeviceIDList{
@@ -343,15 +345,15 @@ func (helper *CryptoHelper) verifyKeysAreOnServer(ctx context.Context) bool {
 	})
 	if err != nil {
 		helper.log.WithLevel(zerolog.FatalLevel).Err(err).Msg("Failed to query own keys to make sure device still exists")
-		os.Exit(33)
+		return false, fmt.Errorf("%w: failed to query own keys to make sure device still exists:%w", ExitError{33}, err)
 	}
 	device, ok := resp.DeviceKeys[helper.client.UserID][helper.client.DeviceID]
 	if ok && len(device.Keys) > 0 {
-		return true
+		return true, nil
 	}
 	helper.log.Warn().Msg("Existing device doesn't have keys on server, resetting crypto")
 	helper.Reset(ctx, false)
-	return false
+	return false, nil
 }
 
 func (helper *CryptoHelper) Start() {

--- a/bridgev2/matrix/exiterror.go
+++ b/bridgev2/matrix/exiterror.go
@@ -1,0 +1,24 @@
+// Copyright (c) 2026 Tulir Asokan
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package matrix
+
+import (
+	"fmt"
+	"os"
+)
+
+type ExitError struct {
+	ExitCode int
+}
+
+func (e ExitError) Error() string {
+	return fmt.Sprintf("exit with code %d", e.ExitCode)
+}
+
+func (e ExitError) Exit() {
+	os.Exit(e.ExitCode)
+}

--- a/bridgev2/matrix/mxmain/main.go
+++ b/bridgev2/matrix/mxmain/main.go
@@ -369,7 +369,10 @@ func (br *BridgeMain) LoadConfig() {
 func (br *BridgeMain) Start() {
 	ctx := br.Log.WithContext(context.Background())
 	err := br.Bridge.StartConnectors(ctx)
-	if err != nil {
+	var exitError matrix.ExitError
+	if errors.As(err, &exitError) {
+		exitError.Exit()
+	} else if err != nil {
 		var dbUpgradeErr bridgev2.DBUpgradeError
 		if errors.As(err, &dbUpgradeErr) {
 			br.LogDBUpgradeErrorAndExit(dbUpgradeErr.Section, dbUpgradeErr.Err, "Failed to initialize database")


### PR DESCRIPTION
Avoid calling os.Exit in the Matrix connector and instead pass it down as an error for mxmain to do.

There are still some places where os.Exit is being called but this covers most of them.

Also fixes the reconnection loop in ensureConnection which would not stop if the start context is canceled.