### PR TITLE
bridgev2/portal: re-emit capability anchors on UpdateCapabilities when homeserver state is missing

### DIFF
--- a/bridgev2/portal.go
+++ b/bridgev2/portal.go
@@ -4319,22 +4319,41 @@ func (portal *Portal) UpdateBridgeInfo(ctx context.Context) {
 func (portal *Portal) UpdateCapabilities(ctx context.Context, source *UserLogin, implicit bool) bool {
 	if portal.MXID == "" {
 		return false
-	} else if !implicit && time.Since(portal.lastCapUpdate) < 24*time.Hour {
-		return false
-	} else if portal.CapState.ID != "" && source.ID != portal.CapState.Source && source.ID != portal.Receiver {
+	}
+	// Check whether capability anchor events (m.bridge, uk.half-shot.bridge,
+	// com.beeper.room_features) still exist on the homeserver. If any is
+	// missing, bypass the throttle and capID short-circuit below so the full
+	// anchor set gets re-emitted. Without this check, a portal whose state
+	// events got lost on the server would never self-heal here — the bridge
+	// would happily return early on both "nothing changed" signals while the
+	// client sees no anchors and disables feature-gated UI.
+	anchorMissing := portal.anyCapabilityAnchorMissing(ctx)
+	if !anchorMissing {
+		if !implicit && time.Since(portal.lastCapUpdate) < 24*time.Hour {
+			return false
+		}
+	}
+	if portal.CapState.ID != "" && source.ID != portal.CapState.Source && source.ID != portal.Receiver {
 		// TODO allow capability state source to change if the old user login is removed from the portal
 		return false
 	}
 	caps := source.Client.GetCapabilities(ctx, portal)
 	capID := caps.GetID()
-	if capID == portal.CapState.ID {
+	if !anchorMissing && capID == portal.CapState.ID {
 		return false
 	}
 	zerolog.Ctx(ctx).Debug().
 		Str("user_login_id", string(source.ID)).
 		Str("old_id", portal.CapState.ID).
 		Str("new_id", capID).
+		Bool("anchor_missing", anchorMissing).
 		Msg("Sending new room capability event")
+	// If the caps event itself wasn't the only thing missing, also re-emit
+	// the bridge info pair so the full anchor set on the homeserver matches
+	// what a fresh portal would have.
+	if anchorMissing {
+		portal.UpdateBridgeInfo(ctx)
+	}
 	success := portal.sendRoomMeta(ctx, nil, time.Now(), event.StateBeeperRoomFeatures, portal.getBridgeInfoStateKey(), caps, false, nil)
 	if !success {
 		return false
@@ -4360,6 +4379,45 @@ func (portal *Portal) UpdateCapabilities(ctx context.Context, source *UserLogin,
 		}
 	}
 	return true
+}
+
+// anyCapabilityAnchorMissing reports whether any of the state events that
+// together define a portal's capability anchor set (m.bridge,
+// uk.half-shot.bridge, com.beeper.room_features) is missing from the
+// homeserver. The check only runs when the matrix connector implements the
+// optional MatrixConnectorWithArbitraryRoomState interface; otherwise it
+// returns false (no self-heal, fall back to the caller's existing behavior).
+// Lookup errors are logged and treated as "not missing" to avoid forcing a
+// re-emit on a transient failure.
+func (portal *Portal) anyCapabilityAnchorMissing(ctx context.Context) bool {
+	connector, ok := portal.Bridge.Matrix.(MatrixConnectorWithArbitraryRoomState)
+	if !ok {
+		return false
+	}
+	log := zerolog.Ctx(ctx)
+	stateKey := portal.getBridgeInfoStateKey()
+	anchorTypes := []event.Type{
+		event.StateBridge,
+		event.StateHalfShotBridge,
+		event.StateBeeperRoomFeatures,
+	}
+	for _, evType := range anchorTypes {
+		evt, err := connector.GetStateEvent(ctx, portal.MXID, evType, stateKey)
+		if err != nil {
+			log.Warn().Err(err).
+				Stringer("event_type", evType).
+				Msg("Failed to check capability anchor event, assuming present")
+			continue
+		}
+		if evt == nil {
+			log.Info().
+				Stringer("event_type", evType).
+				Str("state_key", stateKey).
+				Msg("Capability anchor event missing on homeserver, will re-emit")
+			return true
+		}
+	}
+	return false
 }
 
 func (portal *Portal) sendStateWithIntentOrBot(ctx context.Context, sender MatrixAPI, eventType event.Type, stateKey string, content *event.Content, ts time.Time) (resp *mautrix.RespSendEvent, err error) {


### PR DESCRIPTION
## Problem

`(*Portal).UpdateCapabilities` has two short-circuits that skip re-emission without verifying the capability anchor events still exist on the homeserver:

```go
if !implicit && time.Since(portal.lastCapUpdate) < 24*time.Hour {
    return false
}
...
if capID == portal.CapState.ID {
    return false
}
```

Both fire on healthy portals (correct) and broken portals (bug). When `m.bridge`, `uk.half-shot.bridge`, or `com.beeper.room_features` goes missing from the homeserver but the capability set hasn't changed, the bridge never notices and never re-emits. Clients then fall back to partial/empty capability information and disable feature-gated UI.

I've been tracking this across Beeper's local bridges where it manifests most visibly as "missing Reply" on Desktop, but the mechanism is general — any path that loses a state event on the homeserver can hit this.

## Fix

Add `anyCapabilityAnchorMissing`, which uses the existing optional `MatrixConnectorWithArbitraryRoomState.GetStateEvent` interface to check the three anchor types. When any is missing, `UpdateCapabilities`:

- bypasses the 24h throttle
- bypasses the `capID == CapState.ID` short-circuit
- calls `UpdateBridgeInfo` to re-emit the `m.bridge` / `uk.half-shot.bridge` pair
- proceeds through the existing `sendRoomMeta(..., StateBeeperRoomFeatures, ...)` path to re-emit the capabilities event

Connectors that don't implement `MatrixConnectorWithArbitraryRoomState` fall back to the existing behavior — no self-heal, no regression. Lookup errors on individual anchors are logged and treated as "not missing" so a transient failure doesn't force a re-emit storm.

## Who this helps

Any deployment whose homeserver can drop or fail to persist state events and whose matrix connector can answer `GetStateEvent` lookups. The standard `bridgev2/matrix.Connector` already implements it, so upstream deployments get self-heal for free once this lands.

## Context

On the Beeper side this pairs with a client SDK change that implements `GetStateEvent` on the local matrix connector, so on-device local bridges benefit too. That's a separate PR in the beeper-client-sdk repo and has no ordering dependency with this one — connectors opt in by implementing the interface, and the interface already exists upstream.