### PR TITLE
goolm/crypto: fix typo in package documentation

### DIFF
--- a/crypto/goolm/crypto/doc.go
+++ b/crypto/goolm/crypto/doc.go
@@ -1,2 +1,2 @@
-// Package crpyto provides the nessesary encryption methods for olm/megolm
+// Package crypto provides the nessesary encryption methods for olm/megolm
 package crypto


### PR DESCRIPTION
## Summary

Quality: Typo in package documentation

## Problem

**Severity**: `Low` | **File**: `crypto/goolm/crypto/doc.go:L1`

The package comment in crypto/goolm/crypto/doc.go has a typo: 'crpyto' should be 'crypto'

## Solution

Change 'crpyto' to 'crypto' in the package comment

## Changes

- `crypto/goolm/crypto/doc.go` (modified)