### PR TITLE
bridgev2: respect FetchMessagesResponse.Forward in initial backfill

### DIFF
--- a/bridgev2/portalbackfill.go
+++ b/bridgev2/portalbackfill.go
@@ -85,7 +85,7 @@ func (portal *Portal) doForwardBackfill(ctx context.Context, source *UserLogin, 
 		}
 		return
 	}
-	err = portal.sendBackfill(ctx, source, resp.Messages, true, resp.MarkRead, false, resp.CompleteCallback)
+	err = portal.sendBackfill(ctx, source, resp.Messages, resp.Forward, resp.MarkRead, false, resp.CompleteCallback)
 	if err != nil {
 		log.Err(err).Msg("Failed to send forward backfill")
 	}
@@ -529,8 +529,8 @@ func (portal *Portal) sendBatch(ctx context.Context, source *UserLogin, messages
 		portal.compileBatchMessage(ctx, source, msg, out, inThread)
 	}
 	req := &mautrix.ReqBeeperBatchSend{
-		ForwardIfNoMessages: !forceForward,
 		Forward:             forceForward,
+		ForwardIfNoMessages: false,
 		SendNotification:    !markRead && forceForward && !inThread,
 		Events:              out.Events,
 	}


### PR DESCRIPTION
## What's broken

`doForwardBackfill` hardcodes `forceForward=true` and ignores the bridge's `FetchMessagesResponse.Forward` signal. Bridges that return historical messages on initial portal creation hit `batch_send` with `Forward: true`, and megahungry assigns those old events hs.orders sized for the current moment instead of preserving their original ordering. New live messages arriving afterwards then sort below the backfill anchor.

## Symptom

Beeper users on local-twitter / XChat see this most: new DMs make the chat jump to the top of the inbox, but the message body is buried in the scroll because its sort key is smaller than the historical anchor. Tracked internally under parent issue `BIOS-28716`, full RCA in `PLAT-36307`.

The mechanism isn't XChat-specific. It hits whenever a bridge's initial backfill includes messages older than the wall-clock at portal creation by a meaningful margin. Most local bridges only pull recent history at portal creation so they don't trip it. XChat does because the protocol hands over a year+ of conversation history on first activation.

## Changes

Two hunks in `bridgev2/portalbackfill.go`:

1. `doForwardBackfill`: read `resp.Forward` instead of hardcoding `true`. Bridges that explicitly want forward semantics already set `Forward: true` in their response (mautrix-twitter does this on early-exit paths). The XChat backfill success path leaves `Forward` at the zero value `false`, so this lets that signal reach megahungry.

2. `sendBatch`: set `ForwardIfNoMessages` to `false` instead of deriving it from `!forceForward`. The fallback contract was "if the room is empty, treat as forward anyway". New portals are always empty so the fallback would undo change 1. `doBackwardsBackfill` is unaffected because it only runs when the room already has at least one message.

## Testing

Verified by code reading against rageshake evidence in PLAT-36307. Not run live yet. Worth a smoke test against another local bridge with a fresh portal (e.g. local-telegram) before merge to confirm nothing on the happy path regresses.