### PR TITLE
bridgev2: add bridge_remote_leave config option

### DIFF
--- a/bridgev2/bridgeconfig/config.go
+++ b/bridgev2/bridgeconfig/config.go
@@ -76,6 +76,7 @@ type BridgeConfig struct {
 	UnknownErrorAutoReconnect     time.Duration      `yaml:"unknown_error_auto_reconnect"`
 	UnknownErrorMaxAutoReconnects int                `yaml:"unknown_error_max_auto_reconnects"`
 	BridgeMatrixLeave             bool               `yaml:"bridge_matrix_leave"`
+	BridgeRemoteLeave             bool               `yaml:"bridge_remote_leave"`
 	BridgeNotices                 bool               `yaml:"bridge_notices"`
 	TagOnlyOnCreate               bool               `yaml:"tag_only_on_create"`
 	OnlyBridgeTags                []event.RoomTag    `yaml:"only_bridge_tags"`

--- a/bridgev2/bridgeconfig/upgrade.go
+++ b/bridgev2/bridgeconfig/upgrade.go
@@ -35,6 +35,7 @@ func doUpgrade(helper up.Helper) {
 	helper.Copy(up.Str|up.Int|up.Null, "bridge", "unknown_error_auto_reconnect")
 	helper.Copy(up.Int, "bridge", "unknown_error_max_auto_reconnects")
 	helper.Copy(up.Bool, "bridge", "bridge_matrix_leave")
+	helper.Copy(up.Bool, "bridge", "bridge_remote_leave")
 	helper.Copy(up.Bool, "bridge", "bridge_notices")
 	helper.Copy(up.Bool, "bridge", "tag_only_on_create")
 	helper.Copy(up.List, "bridge", "only_bridge_tags")

--- a/bridgev2/matrix/mxmain/example-config.yaml
+++ b/bridgev2/matrix/mxmain/example-config.yaml
@@ -35,6 +35,12 @@ bridge:
 
     # Should leaving Matrix rooms be bridged as leaving groups on the remote network?
     bridge_matrix_leave: false
+    # Should leaving a group on the remote network kick the user out of the
+    # corresponding Matrix room? When `true`, a remote leave is propagated to
+    # Matrix the same as any other membership change. When `false`, the leave
+    # is dropped so the user keeps access to history and stays in the Matrix
+    # room.
+    bridge_remote_leave: true
     # Should `m.notice` messages be bridged?
     bridge_notices: false
     # Should room tags only be synced when creating the portal? Tags mean things like favorite/pin and archive/low priority.

--- a/bridgev2/portal.go
+++ b/bridgev2/portal.go
@@ -4618,6 +4618,16 @@ func (portal *Portal) syncParticipants(
 		if member.Membership == "" {
 			member.Membership = event.MembershipJoin
 		}
+		// Symmetric with bridge_matrix_leave: when bridge_remote_leave is
+		// disabled, dropping the leave from the remote network keeps the
+		// user in the Matrix room with their existing history.
+		if !portal.Bridge.Config.BridgeRemoteLeave && member.Membership == event.MembershipLeave {
+			log.Debug().
+				Stringer("user_id", extraUserID).
+				Msg("Dropping remote leave: bridge_remote_leave is disabled")
+			delete(currentMembers, extraUserID)
+			return false
+		}
 		if member.PowerLevel != nil {
 			powerChanged = currentPower.EnsureUserLevelAs(portal.Bridge.Bot.GetMXID(), extraUserID, *member.PowerLevel) || powerChanged
 		}


### PR DESCRIPTION
Closes #450.

## Summary

Adds a new `bridge_remote_leave` config option that is the symmetric counterpart of the existing `bridge_matrix_leave`. When the bridge receives a membership-change event from the remote network with `Membership == leave` and the operator has set `bridge_remote_leave: false`, `syncUser` drops the event instead of applying it to the corresponding Matrix room. The user keeps access to the Matrix room and its existing history; new bridged messages between them and the remote group naturally stop because the remote relationship is gone.

Use case from the linked issue: a user leaves a WhatsApp / Signal / Telegram group but wants to keep the history accessible on Matrix, rather than being kicked out of the portal alongside the remote.

## Default

The example config and the upgrade list set the new key to `true`, which preserves the current behavior for existing deployments on a silent config upgrade. Operators that want the new behavior opt in by flipping it to `false`.

## Files touched

| File | Change |
|---|---|
| `bridgev2/bridgeconfig/config.go` | Add `BridgeRemoteLeave bool` field next to `BridgeMatrixLeave` |
| `bridgev2/bridgeconfig/upgrade.go` | `helper.Copy` entry so the key round-trips through config upgrades |
| `bridgev2/matrix/mxmain/example-config.yaml` | New `bridge_remote_leave: true` line with explanatory comment |
| `bridgev2/portal.go` | Drop branch at the top of `syncUser` |

## Scope (intentionally narrow)

The follow-up the issue author suggested — "set the user's power level to 0 and raise the send-message level so the bot can moderate further behavior" — is left for a separate change. That touches the power-level state machine and warrants its own discussion. With this PR in place, the bot can keep the user in the room as a member, and operators can layer the power-level handling on top later.

## Test plan

The diff carries no new test cases (the change is gated by a config-default that preserves existing behavior, and there is no existing membership-sync test scaffold in the repo to extend cheaply). Verified locally:

```
$ go build -tags=goolm ./bridgev2/...
$ go vet -tags=goolm ./bridgev2/...
```

Happy to add a unit / integration test if you want one — let me know your preferred shape.
