### PR TITLE
bridgev2: make portal rejoin events configurable

### DIFF
--- a/bridgev2/bridgeconfig/config.go
+++ b/bridgev2/bridgeconfig/config.go
@@ -75,6 +75,7 @@ type BridgeConfig struct {
 	BridgeStatusNotices           string             `yaml:"bridge_status_notices"`
 	UnknownErrorAutoReconnect     time.Duration      `yaml:"unknown_error_auto_reconnect"`
 	UnknownErrorMaxAutoReconnects int                `yaml:"unknown_error_max_auto_reconnects"`
+	RejoinOnEvents                RejoinOnEvents     `yaml:"rejoin_on_events"`
 	BridgeMatrixLeave             bool               `yaml:"bridge_matrix_leave"`
 	BridgeNotices                 bool               `yaml:"bridge_notices"`
 	TagOnlyOnCreate               bool               `yaml:"tag_only_on_create"`

--- a/bridgev2/bridgeconfig/rejoin.go
+++ b/bridgev2/bridgeconfig/rejoin.go
@@ -1,0 +1,77 @@
+// Copyright (c) 2026 Tulir Asokan
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package bridgeconfig
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+)
+
+const (
+	RejoinEventMessage         = "message"
+	RejoinEventMessageUpsert   = "message_upsert"
+	RejoinEventEdit            = "edit"
+	RejoinEventReaction        = "reaction"
+	RejoinEventReactionRemove  = "reaction_remove"
+	RejoinEventReactionSync    = "reaction_sync"
+	RejoinEventMessageRemove   = "message_remove"
+	RejoinEventReadReceipt     = "read_receipt"
+	RejoinEventDeliveryReceipt = "delivery_receipt"
+	RejoinEventMarkUnread      = "mark_unread"
+	RejoinEventTyping          = "typing"
+	RejoinEventChatInfoChange  = "chat_info_change"
+	RejoinEventChatResync      = "chat_resync"
+	RejoinEventBackfill        = "backfill"
+)
+
+var (
+	AllRejoinEventNames = []string{
+		RejoinEventMessage,
+		RejoinEventMessageUpsert,
+		RejoinEventEdit,
+		RejoinEventReaction,
+		RejoinEventReactionRemove,
+		RejoinEventReactionSync,
+		RejoinEventMessageRemove,
+		RejoinEventReadReceipt,
+		RejoinEventDeliveryReceipt,
+		RejoinEventMarkUnread,
+		RejoinEventTyping,
+		RejoinEventChatInfoChange,
+		RejoinEventChatResync,
+		RejoinEventBackfill,
+	}
+	DefaultRejoinOnEvents = []string{
+		RejoinEventMessage,
+		RejoinEventMessageUpsert,
+		RejoinEventEdit,
+		RejoinEventReaction,
+		RejoinEventReactionRemove,
+		RejoinEventReactionSync,
+		RejoinEventMessageRemove,
+		RejoinEventBackfill,
+	}
+)
+
+type RejoinOnEvents []string
+
+func (roe RejoinOnEvents) Contains(evtName string) bool {
+	if roe == nil {
+		return slices.Contains(DefaultRejoinOnEvents, evtName)
+	}
+	return slices.Contains(roe, evtName)
+}
+
+func (roe RejoinOnEvents) Validate() error {
+	for _, evtName := range roe {
+		if !slices.Contains(AllRejoinEventNames, evtName) {
+			return fmt.Errorf("unknown bridge.rejoin_on_events value %q (allowed values: %s)", evtName, strings.Join(AllRejoinEventNames, ", "))
+		}
+	}
+	return nil
+}

--- a/bridgev2/bridgeconfig/upgrade.go
+++ b/bridgev2/bridgeconfig/upgrade.go
@@ -34,6 +34,7 @@ func doUpgrade(helper up.Helper) {
 	helper.Copy(up.Str|up.Null, "bridge", "bridge_status_notices")
 	helper.Copy(up.Str|up.Int|up.Null, "bridge", "unknown_error_auto_reconnect")
 	helper.Copy(up.Int, "bridge", "unknown_error_max_auto_reconnects")
+	helper.Copy(up.List, "bridge", "rejoin_on_events")
 	helper.Copy(up.Bool, "bridge", "bridge_matrix_leave")
 	helper.Copy(up.Bool, "bridge", "bridge_notices")
 	helper.Copy(up.Bool, "bridge", "tag_only_on_create")

--- a/bridgev2/matrix/mxmain/example-config.yaml
+++ b/bridgev2/matrix/mxmain/example-config.yaml
@@ -32,6 +32,19 @@ bridge:
     # Maximum number of times to do the auto-reconnect above.
     # The counter is per login, but is never reset except on logout and restart.
     unknown_error_max_auto_reconnects: 10
+    # Remote events that should rejoin/re-invite Matrix users who previously left a portal room.
+    # Permitted values: message, message_upsert, edit, reaction, reaction_remove, reaction_sync,
+    # message_remove, read_receipt, delivery_receipt, mark_unread, typing, chat_info_change,
+    # chat_resync, backfill
+    rejoin_on_events:
+        - message
+        - message_upsert
+        - edit
+        - reaction
+        - reaction_remove
+        - reaction_sync
+        - message_remove
+        - backfill
 
     # Should leaving Matrix rooms be bridged as leaving groups on the remote network?
     bridge_matrix_leave: false

--- a/bridgev2/matrix/mxmain/main.go
+++ b/bridgev2/matrix/mxmain/main.go
@@ -362,6 +362,11 @@ func (br *BridgeMain) LoadConfig() {
 			os.Exit(10)
 		}
 	}
+	err = cfg.Bridge.RejoinOnEvents.Validate()
+	if err != nil {
+		_, _ = fmt.Fprintln(os.Stderr, "Invalid config:", err)
+		os.Exit(10)
+	}
 	br.Config = &cfg
 }
 

--- a/bridgev2/networkinterface.go
+++ b/bridgev2/networkinterface.go
@@ -19,6 +19,7 @@ import (
 	"go.mau.fi/util/random"
 
 	"maunium.net/go/mautrix"
+	"maunium.net/go/mautrix/bridgev2/bridgeconfig"
 	"maunium.net/go/mautrix/bridgev2/database"
 	"maunium.net/go/mautrix/bridgev2/networkid"
 	"maunium.net/go/mautrix/event"
@@ -1116,6 +1117,41 @@ func (ret RemoteEventType) String() string {
 		return "RemoteEventBackfill"
 	default:
 		return fmt.Sprintf("RemoteEventType(%d)", int(ret))
+	}
+}
+
+func (ret RemoteEventType) RejoinEventName() string {
+	switch ret {
+	case RemoteEventMessage:
+		return bridgeconfig.RejoinEventMessage
+	case RemoteEventMessageUpsert:
+		return bridgeconfig.RejoinEventMessageUpsert
+	case RemoteEventEdit:
+		return bridgeconfig.RejoinEventEdit
+	case RemoteEventReaction:
+		return bridgeconfig.RejoinEventReaction
+	case RemoteEventReactionRemove:
+		return bridgeconfig.RejoinEventReactionRemove
+	case RemoteEventReactionSync:
+		return bridgeconfig.RejoinEventReactionSync
+	case RemoteEventMessageRemove:
+		return bridgeconfig.RejoinEventMessageRemove
+	case RemoteEventReadReceipt:
+		return bridgeconfig.RejoinEventReadReceipt
+	case RemoteEventDeliveryReceipt:
+		return bridgeconfig.RejoinEventDeliveryReceipt
+	case RemoteEventMarkUnread:
+		return bridgeconfig.RejoinEventMarkUnread
+	case RemoteEventTyping:
+		return bridgeconfig.RejoinEventTyping
+	case RemoteEventChatInfoChange:
+		return bridgeconfig.RejoinEventChatInfoChange
+	case RemoteEventChatResync:
+		return bridgeconfig.RejoinEventChatResync
+	case RemoteEventBackfill:
+		return bridgeconfig.RejoinEventBackfill
+	default:
+		return ""
 	}
 }
 

--- a/bridgev2/portal.go
+++ b/bridgev2/portal.go
@@ -42,9 +42,10 @@ type portalMatrixEvent struct {
 }
 
 type portalRemoteEvent struct {
-	evt     RemoteEvent
-	source  *UserLogin
-	evtType RemoteEventType
+	evt             RemoteEvent
+	source          *UserLogin
+	evtType         RemoteEventType
+	allowUserRejoin bool
 }
 
 type portalCreateEvent struct {
@@ -533,6 +534,7 @@ func (portal *Portal) getEventCtxWithLog(rawEvt any, idx int) context.Context {
 		}
 		ctx := portal.backgroundCtx
 		ctx = context.WithValue(ctx, contextKeyRemoteEvent, evt.evt)
+		ctx = contextWithRemoteEventRejoin(ctx, evt.allowUserRejoin)
 		ctx = logWith.Logger().WithContext(ctx)
 		if ctxMut, ok := evt.evt.(RemoteEventWithContextMutation); ok {
 			ctx = ctxMut.MutateContext(ctx)
@@ -3937,8 +3939,9 @@ func (portal *Portal) handleRemoteChatDelete(ctx context.Context, source *UserLo
 					child:                        child.PortalKey,
 					done:                         wg.Done,
 				},
-				source:  source,
-				evtType: RemoteEventChatDelete,
+				source:          source,
+				evtType:         RemoteEventChatDelete,
+				allowUserRejoin: remoteEventRejoinAllowed(ctx),
 			})
 		}
 		wg.Wait()
@@ -3992,7 +3995,7 @@ func (portal *Portal) ProcessChatInfoChange(ctx context.Context, sender EventSen
 	if change.ChatInfo != nil {
 		portal.UpdateInfo(ctx, change.ChatInfo, source, intent, ts)
 	}
-	if change.MemberChanges != nil {
+	if change.MemberChanges != nil && remoteEventRejoinAllowed(ctx) {
 		err := portal.syncParticipants(ctx, change.MemberChanges, source, intent, ts)
 		if err != nil {
 			zerolog.Ctx(ctx).Err(err).Msg("Failed to sync room members")
@@ -5040,7 +5043,7 @@ func (portal *Portal) UpdateInfo(ctx context.Context, info *ChatInfo, source *Us
 		changed = true
 		portal.MessageRequest = *info.MessageRequest
 	}
-	if info.Members != nil && portal.MXID != "" && source != nil {
+	if info.Members != nil && portal.MXID != "" && source != nil && remoteEventRejoinAllowed(ctx) {
 		err := portal.syncParticipants(ctx, info.Members, source, nil, time.Time{})
 		if err != nil {
 			zerolog.Ctx(ctx).Err(err).Msg("Failed to sync room members")

--- a/bridgev2/queue.go
+++ b/bridgev2/queue.go
@@ -234,6 +234,9 @@ func (ul *UserLogin) QueueRemoteEvent(evt RemoteEvent) EventHandlingResult {
 func (br *Bridge) QueueRemoteEvent(login *UserLogin, evt RemoteEvent) EventHandlingResult {
 	log := login.Log
 	ctx := log.WithContext(br.BackgroundCtx)
+	evtType := evt.GetType()
+	rejoinOnEvent := br.Config.RejoinOnEvents.Contains(evtType.RejoinEventName())
+	ctx = contextWithRemoteEventRejoin(ctx, rejoinOnEvent)
 	maybeUncertain, ok := evt.(RemoteEventWithUncertainPortalReceiver)
 	isUncertain := ok && maybeUncertain.PortalReceiverIsUncertain()
 	key := evt.GetPortalKey()
@@ -250,16 +253,19 @@ func (br *Bridge) QueueRemoteEvent(login *UserLogin, evt RemoteEvent) EventHandl
 		return EventHandlingResultFailed.WithError(fmt.Errorf("failed to get portal: %w", err))
 	} else if portal == nil {
 		log.Warn().
-			Stringer("event_type", evt.GetType()).
+			Stringer("event_type", evtType).
 			Object("portal_key", key).
 			Bool("uncertain_receiver", isUncertain).
 			Msg("Portal not found to handle remote event")
 		return EventHandlingResultIgnored
 	}
 	// TODO put this in a better place, and maybe cache to avoid constant db queries
-	login.MarkInPortal(ctx, portal)
+	if rejoinOnEvent {
+		login.MarkInPortal(ctx, portal)
+	}
 	return portal.queueEvent(ctx, &portalRemoteEvent{
-		evt:    evt,
-		source: login,
+		evt:             evt,
+		source:          login,
+		allowUserRejoin: rejoinOnEvent,
 	})
 }

--- a/bridgev2/space.go
+++ b/bridgev2/space.go
@@ -20,7 +20,21 @@ import (
 	"maunium.net/go/mautrix/id"
 )
 
+type rejoinOnRemoteEventContextKey struct{}
+
+func contextWithRemoteEventRejoin(ctx context.Context, allowed bool) context.Context {
+	return context.WithValue(ctx, rejoinOnRemoteEventContextKey{}, allowed)
+}
+
+func remoteEventRejoinAllowed(ctx context.Context) bool {
+	allowed, ok := ctx.Value(rejoinOnRemoteEventContextKey{}).(bool)
+	return !ok || allowed
+}
+
 func (ul *UserLogin) MarkInPortal(ctx context.Context, portal *Portal) {
+	if !remoteEventRejoinAllowed(ctx) {
+		return
+	}
 	if ul.inPortalCache.Has(portal.PortalKey) {
 		return
 	}


### PR DESCRIPTION
## Summary
- add bridge.rejoin_on_events as a shared bridgev2 config option
- map RemoteEventType values to stable lowercase config names and validate unknown values at startup
- carry the rejoin policy decision from QueueRemoteEvent into portal event handling so chat info/resync participant sync cannot repair a local leave unless allowed

## Default behavior
The default list keeps visible content events enabled: messages, message upserts, edits, reactions, reaction removals, reaction syncs, message removals, and backfill. Deployments can override the list to a narrower policy, e.g. message/message_upsert only.

## Verification
- go test ./bridgev2
- git diff --check

Fixes #506