### PR TITLE
bridgeconfig: expose max HTTP backoff configuration

### DIFF
--- a/appservice/appservice.go
+++ b/appservice/appservice.go
@@ -168,6 +168,7 @@ type AppService struct {
 	SpecVersions *mautrix.RespVersions
 
 	DefaultHTTPRetries int
+	MaxHTTPBackoff     time.Duration
 
 	Live  bool
 	Ready bool
@@ -369,6 +370,7 @@ func (as *AppService) NewMautrixClient(userID id.UserID) *mautrix.Client {
 		Log:                 as.Log.With().Stringer("as_user_id", userID).Logger(),
 		Client:              as.HTTPClient,
 		DefaultHTTPRetries:  as.DefaultHTTPRetries,
+		MaxHTTPBackoff:      as.MaxHTTPBackoff,
 		SpecVersions:        as.SpecVersions,
 	}
 }

--- a/bridgev2/bridgeconfig/appservice.go
+++ b/bridgev2/bridgeconfig/appservice.go
@@ -111,6 +111,7 @@ func (config *Config) MakeAppService() *appservice.AppService {
 	as.Host.Port = config.AppService.Port
 	as.Registration = config.AppService.GetRegistration()
 	as.DefaultHTTPRetries = config.Homeserver.RetryLimit
+	as.MaxHTTPBackoff = config.Homeserver.MaxRetryBackoff
 	config.Encryption.applyUnstableFlags(as.Registration)
 	return as
 }

--- a/bridgev2/bridgeconfig/homeserver.go
+++ b/bridgev2/bridgeconfig/homeserver.go
@@ -6,6 +6,8 @@
 
 package bridgeconfig
 
+import "time"
+
 type HomeserverSoftware string
 
 const (
@@ -36,5 +38,6 @@ type HomeserverConfig struct {
 	WSProxy        string `yaml:"websocket_proxy"`
 	WSPingInterval int    `yaml:"ping_interval_seconds"`
 
-	RetryLimit int `yaml:"retry_limit"`
+	RetryLimit      int           `yaml:"retry_limit"`
+	MaxRetryBackoff time.Duration `yaml:"max_retry_backoff"`
 }

--- a/bridgev2/bridgeconfig/upgrade.go
+++ b/bridgev2/bridgeconfig/upgrade.go
@@ -88,6 +88,7 @@ func doUpgrade(helper up.Helper) {
 	helper.Copy(up.Bool, "homeserver", "websocket")
 	helper.Copy(up.Int, "homeserver", "ping_interval_seconds")
 	helper.Copy(up.Int, "homeserver", "retry_limit")
+	helper.Copy(up.Str, "homeserver", "max_retry_backoff")
 
 	helper.Copy(up.Str|up.Null, "appservice", "address")
 	helper.Copy(up.Str|up.Null, "appservice", "public_address")

--- a/bridgev2/matrix/mxmain/example-config.yaml
+++ b/bridgev2/matrix/mxmain/example-config.yaml
@@ -208,6 +208,9 @@ homeserver:
     # When requests to the homeserver fail with a 502/503/504/429 status or a network error,
     # how many times should the bridge retry the request before giving up?
     retry_limit: 4
+    # Maximum time to wait between HTTP retries to the homeserver. Applies to both the
+    # exponential backoff from gateway/network errors and to 429 errors.
+    max_retry_backoff: 10m
 
 # Application service host/registration related details.
 # Changing these values requires regeneration of the registration (except when noted otherwise)


### PR DESCRIPTION
Exposes https://github.com/mautrix/go/commit/d6034a37aae699d9dfd7c65658e48b317e75f2b2 as bridge config.