### PR TITLE
bridgev2: scaffold MSC4350 config flag

### DIFF
--- a/bridgev2/bridgeconfig/encryption.go
+++ b/bridgev2/bridgeconfig/encryption.go
@@ -16,8 +16,19 @@ type EncryptionConfig struct {
 	Require    bool `yaml:"require"`
 	Appservice bool `yaml:"appservice"`
 	MSC4190    bool `yaml:"msc4190"`
-	MSC4392    bool `yaml:"msc4392"`
-	SelfSign   bool `yaml:"self_sign"`
+	// MSC4350: Permitting encryption impersonation for appservices.
+	// When enabled, the bridge will create an "impersonatable" device for
+	// each ghost user (and double-puppeted real user) pointing at the
+	// bridge bot's device as the impersonator. This lets recipient clients
+	// legitimately accept events signed by the bridge bot's device when
+	// attributed to a ghost, removing the "sender doesn't match device
+	// owner" warning. Requires homeserver support for MSC4350 (synapse
+	// experimental_features.msc4350_enabled) and a cross-signed bridge bot
+	// device (encryption.self_sign).
+	// See https://github.com/matrix-org/matrix-spec-proposals/pull/4350
+	MSC4350  bool `yaml:"msc4350"`
+	MSC4392  bool `yaml:"msc4392"`
+	SelfSign bool `yaml:"self_sign"`
 
 	PlaintextMentions bool `yaml:"plaintext_mentions"`
 

--- a/bridgev2/bridgeconfig/upgrade.go
+++ b/bridgev2/bridgeconfig/upgrade.go
@@ -172,6 +172,7 @@ func doUpgrade(helper up.Helper) {
 	} else {
 		helper.Copy(up.Bool, "encryption", "msc4190")
 	}
+	helper.Copy(up.Bool, "encryption", "msc4350")
 	helper.Copy(up.Bool, "encryption", "msc4392")
 	helper.Copy(up.Bool, "encryption", "self_sign")
 	helper.Copy(up.Bool, "encryption", "allow_key_sharing")

--- a/bridgev2/matrix/crypto.go
+++ b/bridgev2/matrix/crypto.go
@@ -612,6 +612,21 @@ func (helper *CryptoHelper) EnsureImpersonatableDevice(ctx context.Context, ghos
 	ghostClient := helper.bridge.AS.NewMautrixClient(ghostUserID)
 	ghostClient.DeviceID = MSC4350ImpersonatableDeviceID
 	ghostClient.SetAppServiceDeviceID = true
+
+	// MSC4326 device masquerading rejects /keys/upload for a device that
+	// hasn't been registered yet ("Application service trying to use a
+	// device that doesn't exist"). Create the device first via the
+	// MSC4190 PUT /devices/{deviceID} flow, then upload its keys.
+	// CreateDeviceMSC4190 is idempotent in synapse - re-creating the
+	// same device_id is a no-op rather than an error.
+	if err := ghostClient.CreateDeviceMSC4190(
+		ctx,
+		MSC4350ImpersonatableDeviceID,
+		"MSC4350 impersonatable device",
+	); err != nil {
+		return fmt.Errorf("register impersonatable device for %s: %w", ghostUserID, err)
+	}
+
 	if _, err := UploadImpersonatableDevice(ctx, account, ghostClient, ghostUserID, bot); err != nil {
 		return err
 	}

--- a/bridgev2/matrix/crypto.go
+++ b/bridgev2/matrix/crypto.go
@@ -56,6 +56,13 @@ type CryptoHelper struct {
 	cancelSync func()
 
 	cancelPeriodicDeleteLoop func()
+
+	// impersonatableMu guards impersonatableUploaded. It is held only
+	// long enough to read/insert into the map; the actual /keys/upload
+	// happens outside the lock so a slow homeserver can't block other
+	// ghosts from being encrypted for.
+	impersonatableMu       sync.Mutex
+	impersonatableUploaded map[id.UserID]struct{}
 }
 
 func NewCryptoHelper(c *Connector) Crypto {
@@ -541,6 +548,60 @@ func (helper *CryptoHelper) HandleMemberEvent(ctx context.Context, evt *event.Ev
 // ShareKeys uploads the given number of one-time-keys to the server.
 func (helper *CryptoHelper) ShareKeys(ctx context.Context) error {
 	return helper.mach.ShareKeys(ctx, -1)
+}
+
+// EnsureImpersonatableDevice uploads an MSC4350 impersonatable device
+// for the given ghost user, with the bridge bot as the impersonator, if
+// the bridge is configured for MSC4350 and the upload hasn't been
+// performed yet for this ghost in the current process.
+//
+// Synapse treats re-uploads of the same device_id as idempotent
+// refreshes, so cache misses across bridge restarts heal themselves on
+// next call - persistence is an efficiency improvement, not a
+// correctness requirement.
+//
+// Returns nil and skips silently when encryption.msc4350 is disabled or
+// the crypto helper hasn't finished initialising; both are normal
+// states during bridge startup.
+func (helper *CryptoHelper) EnsureImpersonatableDevice(ctx context.Context, ghostUserID id.UserID) error {
+	if helper == nil || !helper.bridge.Config.Encryption.MSC4350 {
+		return nil
+	}
+	if helper.mach == nil || helper.client == nil {
+		return nil
+	}
+	account := helper.mach.GetAccount()
+	if account == nil {
+		return nil
+	}
+
+	helper.impersonatableMu.Lock()
+	if helper.impersonatableUploaded == nil {
+		helper.impersonatableUploaded = make(map[id.UserID]struct{})
+	}
+	if _, alreadyUploaded := helper.impersonatableUploaded[ghostUserID]; alreadyUploaded {
+		helper.impersonatableMu.Unlock()
+		return nil
+	}
+	helper.impersonatableMu.Unlock()
+
+	signingKey, identityKey := account.Keys()
+	bot := ImpersonatorBotIdentity{
+		UserID:      helper.client.UserID,
+		DeviceID:    helper.client.DeviceID,
+		SigningKey:  signingKey,
+		IdentityKey: identityKey,
+	}
+
+	ghostClient := helper.bridge.AS.Client(ghostUserID)
+	if _, err := UploadImpersonatableDevice(ctx, account, ghostClient, ghostUserID, bot); err != nil {
+		return err
+	}
+
+	helper.impersonatableMu.Lock()
+	helper.impersonatableUploaded[ghostUserID] = struct{}{}
+	helper.impersonatableMu.Unlock()
+	return nil
 }
 
 func (helper *CryptoHelper) BeeperStreamPublisher() bridgev2.BeeperStreamPublisher {

--- a/bridgev2/matrix/crypto.go
+++ b/bridgev2/matrix/crypto.go
@@ -602,7 +602,16 @@ func (helper *CryptoHelper) EnsureImpersonatableDevice(ctx context.Context, ghos
 		IdentityKey: identityKey,
 	}
 
-	ghostClient := helper.bridge.AS.Client(ghostUserID)
+	// /keys/upload requires synapse to know the device_id the keys are
+	// being uploaded for. With appservice masquerading that comes from
+	// the ?device_id= query param (MSC3202). The shared cached client
+	// returned by as.Client doesn't have DeviceID set - it's used for
+	// ghost intent operations that don't tie to a specific device. Build
+	// a one-off client with the impersonatable device id pinned so the
+	// URL builder appends ?device_id= and ?org.matrix.msc3202.device_id=.
+	ghostClient := helper.bridge.AS.NewMautrixClient(ghostUserID)
+	ghostClient.DeviceID = MSC4350ImpersonatableDeviceID
+	ghostClient.SetAppServiceDeviceID = true
 	if _, err := UploadImpersonatableDevice(ctx, account, ghostClient, ghostUserID, bot); err != nil {
 		return err
 	}

--- a/bridgev2/matrix/crypto.go
+++ b/bridgev2/matrix/crypto.go
@@ -564,14 +564,6 @@ func (helper *CryptoHelper) ShareKeys(ctx context.Context) error {
 // the crypto helper hasn't finished initialising; both are normal
 // states during bridge startup.
 func (helper *CryptoHelper) EnsureImpersonatableDevice(ctx context.Context, ghostUserID id.UserID) error {
-	// MSC4350 debug instrumentation (temporary - revert before upstreaming).
-	helper.log.Info().
-		Stringer("ghost", ghostUserID).
-		Bool("helper_nil", helper == nil).
-		Bool("config_msc4350", helper != nil && helper.bridge.Config.Encryption.MSC4350).
-		Bool("mach_nil", helper == nil || helper.mach == nil).
-		Bool("client_nil", helper == nil || helper.client == nil).
-		Msg("MSC4350 EnsureImpersonatableDevice entered")
 	if helper == nil || !helper.bridge.Config.Encryption.MSC4350 {
 		return nil
 	}
@@ -580,7 +572,6 @@ func (helper *CryptoHelper) EnsureImpersonatableDevice(ctx context.Context, ghos
 	}
 	account := helper.mach.GetAccount()
 	if account == nil {
-		helper.log.Info().Msg("MSC4350 account is nil, skipping")
 		return nil
 	}
 

--- a/bridgev2/matrix/crypto.go
+++ b/bridgev2/matrix/crypto.go
@@ -602,23 +602,28 @@ func (helper *CryptoHelper) EnsureImpersonatableDevice(ctx context.Context, ghos
 		IdentityKey: identityKey,
 	}
 
-	// /keys/upload requires synapse to know the device_id the keys are
-	// being uploaded for. With appservice masquerading that comes from
-	// the ?device_id= query param (MSC3202). The shared cached client
-	// returned by as.Client doesn't have DeviceID set - it's used for
-	// ghost intent operations that don't tie to a specific device. Build
-	// a one-off client with the impersonatable device id pinned so the
-	// URL builder appends ?device_id= and ?org.matrix.msc3202.device_id=.
+	// Two-step flow:
+	//
+	//   1. PUT /v3/devices/{deviceID}?user_id=<ghost>           (MSC4190 device-create)
+	//   2. POST /v3/keys/upload?user_id=<ghost>&device_id=<X>   (MSC4326 device-keys-upload)
+	//
+	// Step 1 must NOT include a ?device_id= query parameter:
+	// synapse's appservice auth layer treats ?device_id= as
+	// "I claim to already be this device", looks up the device,
+	// and rejects with M_UNKNOWN_DEVICE if it doesn't exist yet -
+	// blocking the very create-device request that would have
+	// brought it into existence. The PUT path itself names the
+	// device, so step 1 doesn't need the query param.
+	//
+	// Step 2 DOES need ?device_id= because /keys/upload otherwise
+	// has no way to know which device the keys belong to.
+	//
+	// We use one client (NewMautrixClient gives us a fresh one that
+	// isn't cached for general use) and toggle SetAppServiceDeviceID
+	// between the calls.
 	ghostClient := helper.bridge.AS.NewMautrixClient(ghostUserID)
-	ghostClient.DeviceID = MSC4350ImpersonatableDeviceID
-	ghostClient.SetAppServiceDeviceID = true
 
-	// MSC4326 device masquerading rejects /keys/upload for a device that
-	// hasn't been registered yet ("Application service trying to use a
-	// device that doesn't exist"). Create the device first via the
-	// MSC4190 PUT /devices/{deviceID} flow, then upload its keys.
-	// CreateDeviceMSC4190 is idempotent in synapse - re-creating the
-	// same device_id is a no-op rather than an error.
+	// Step 1: register device. No DeviceID query param yet.
 	if err := ghostClient.CreateDeviceMSC4190(
 		ctx,
 		MSC4350ImpersonatableDeviceID,
@@ -627,6 +632,10 @@ func (helper *CryptoHelper) EnsureImpersonatableDevice(ctx context.Context, ghos
 		return fmt.Errorf("register impersonatable device for %s: %w", ghostUserID, err)
 	}
 
+	// Step 2: upload device keys. Now the device exists and we can
+	// claim to be it via the ?device_id= query param.
+	ghostClient.DeviceID = MSC4350ImpersonatableDeviceID
+	ghostClient.SetAppServiceDeviceID = true
 	if _, err := UploadImpersonatableDevice(ctx, account, ghostClient, ghostUserID, bot); err != nil {
 		return err
 	}

--- a/bridgev2/matrix/crypto.go
+++ b/bridgev2/matrix/crypto.go
@@ -564,6 +564,14 @@ func (helper *CryptoHelper) ShareKeys(ctx context.Context) error {
 // the crypto helper hasn't finished initialising; both are normal
 // states during bridge startup.
 func (helper *CryptoHelper) EnsureImpersonatableDevice(ctx context.Context, ghostUserID id.UserID) error {
+	// MSC4350 debug instrumentation (temporary - revert before upstreaming).
+	helper.log.Info().
+		Stringer("ghost", ghostUserID).
+		Bool("helper_nil", helper == nil).
+		Bool("config_msc4350", helper != nil && helper.bridge.Config.Encryption.MSC4350).
+		Bool("mach_nil", helper == nil || helper.mach == nil).
+		Bool("client_nil", helper == nil || helper.client == nil).
+		Msg("MSC4350 EnsureImpersonatableDevice entered")
 	if helper == nil || !helper.bridge.Config.Encryption.MSC4350 {
 		return nil
 	}
@@ -572,6 +580,7 @@ func (helper *CryptoHelper) EnsureImpersonatableDevice(ctx context.Context, ghos
 	}
 	account := helper.mach.GetAccount()
 	if account == nil {
+		helper.log.Info().Msg("MSC4350 account is nil, skipping")
 		return nil
 	}
 

--- a/bridgev2/matrix/impersonator.go
+++ b/bridgev2/matrix/impersonator.go
@@ -1,0 +1,104 @@
+// Copyright (c) 2026 Jonathan Page (benmichael)
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package matrix
+
+import (
+	"fmt"
+
+	"maunium.net/go/mautrix"
+	"maunium.net/go/mautrix/crypto/signatures"
+	"maunium.net/go/mautrix/id"
+)
+
+// MSC4350ImpersonatableDeviceID is the stable device ID we use for each
+// ghost user's impersonatable device. Using a constant means a re-upload
+// over the same device ID is treated as an idempotent refresh by the
+// homeserver instead of accumulating a new device per restart.
+//
+// The exact value is opaque to the protocol; clients only care that it
+// matches the device_id embedded inside an event encrypted via the
+// impersonator path.
+const MSC4350ImpersonatableDeviceID id.DeviceID = "MSC4350IMPERSONATABLE"
+
+// ImpersonatorSigner is the subset of crypto.OlmAccount used by
+// BuildImpersonatableDeviceKeys. Defined here so tests can substitute a
+// deterministic signer without standing up a full Olm account.
+type ImpersonatorSigner interface {
+	SignJSON(obj any) (string, error)
+}
+
+// BuildImpersonatableDeviceKeys constructs (but does not upload) a valid
+// MSC4350 impersonatable device entry for the given ghost user, with the
+// bridge bot embedded as the impersonator and a signature produced by
+// signer (which MUST be the bot's Olm signing key).
+//
+// The returned DeviceKeys is ready to be PUT via /keys/upload while
+// masquerading as ghostUserID (per MSC4326). It satisfies the structural
+// requirements of MSC4350:
+//   - algorithms: []
+//   - keys: {}
+//   - fi.mau.msc4350.impersonator: bot device-keys-like object (no
+//     signatures field, per spec)
+//   - signatures: a single signature from the bot's ed25519 device key
+//
+// Signing is performed over the canonical JSON form of the entry minus
+// its own signatures and unsigned fields, matching Synapse's verification
+// path implemented in handlers/e2e_keys.py._handle_msc4350_impersonator.
+func BuildImpersonatableDeviceKeys(
+	signer ImpersonatorSigner,
+	ghostUserID id.UserID,
+	ghostDeviceID id.DeviceID,
+	botUserID id.UserID,
+	botDeviceID id.DeviceID,
+	botSigningKey id.SigningKey,
+	botIdentityKey id.IdentityKey,
+) (*mautrix.DeviceKeys, error) {
+	if signer == nil {
+		return nil, fmt.Errorf("impersonator signer is required")
+	}
+	if ghostUserID == "" || ghostDeviceID == "" {
+		return nil, fmt.Errorf("ghost user_id and device_id are required")
+	}
+	if botUserID == "" || botDeviceID == "" {
+		return nil, fmt.Errorf("bot user_id and device_id are required")
+	}
+	if botSigningKey == "" || botIdentityKey == "" {
+		return nil, fmt.Errorf("bot signing_key and identity_key are required")
+	}
+
+	impersonatable := &mautrix.DeviceKeys{
+		UserID:     ghostUserID,
+		DeviceID:   ghostDeviceID,
+		Algorithms: []id.Algorithm{},
+		Keys:       mautrix.KeyMap{},
+		MSC4350Impersonator: &mautrix.ImpersonatorDevice{
+			UserID:   botUserID,
+			DeviceID: botDeviceID,
+			Algorithms: []id.Algorithm{
+				id.AlgorithmMegolmV1,
+				id.AlgorithmOlmV1,
+			},
+			Keys: mautrix.KeyMap{
+				id.NewDeviceKeyID(id.KeyAlgorithmCurve25519, botDeviceID): string(botIdentityKey),
+				id.NewDeviceKeyID(id.KeyAlgorithmEd25519, botDeviceID):    string(botSigningKey),
+			},
+		},
+	}
+
+	sig, err := signer.SignJSON(impersonatable)
+	if err != nil {
+		return nil, fmt.Errorf("sign impersonatable device: %w", err)
+	}
+
+	impersonatable.Signatures = signatures.NewSingleSignature(
+		botUserID,
+		id.KeyAlgorithmEd25519,
+		botDeviceID.String(),
+		sig,
+	)
+	return impersonatable, nil
+}

--- a/bridgev2/matrix/impersonator.go
+++ b/bridgev2/matrix/impersonator.go
@@ -7,6 +7,7 @@
 package matrix
 
 import (
+	"context"
 	"fmt"
 
 	"maunium.net/go/mautrix"
@@ -101,4 +102,70 @@ func BuildImpersonatableDeviceKeys(
 		sig,
 	)
 	return impersonatable, nil
+}
+
+// ImpersonatorBotIdentity carries the bot-side inputs to an impersonatable
+// device upload: the bot's user_id/device_id and the public key material
+// that needs to be embedded inside the ghost's device entry.
+type ImpersonatorBotIdentity struct {
+	UserID      id.UserID
+	DeviceID    id.DeviceID
+	SigningKey  id.SigningKey
+	IdentityKey id.IdentityKey
+}
+
+// KeysUploader is the subset of *mautrix.Client used to upload device
+// keys. Defined here so tests can substitute a mock recorder instead of
+// standing up an HTTP server.
+type KeysUploader interface {
+	UploadKeys(ctx context.Context, req *mautrix.ReqUploadKeys) (*mautrix.RespUploadKeys, error)
+}
+
+// Compile-time guard: if the *mautrix.Client.UploadKeys signature ever
+// drifts, this line breaks the build instead of failing silently at
+// call sites.
+var _ KeysUploader = (*mautrix.Client)(nil)
+
+// UploadImpersonatableDevice builds an MSC4350 impersonatable device for
+// the given ghost and uploads it via /keys/upload.
+//
+// uploader MUST be authenticated as the ghost — for an appservice
+// bridge that is whatever the masquerade machinery returns from
+// as.Client(ghostUserID), which auto-appends ?user_id=<ghost> per the
+// appservice spec / MSC4326. We do not perform the masquerade ourselves;
+// the caller is responsible for handing us a correctly-scoped client.
+//
+// Synapse's MSC4350 implementation accepts a re-upload of the same
+// device_id as an idempotent refresh, so calling this more than once
+// for the same ghost is safe — but bridges should still avoid the
+// network round-trip by tracking which ghosts already have an
+// impersonatable device. That persistence layer lands in the next
+// commit; this function intentionally does not consult or update any
+// store.
+//
+// Returns the constructed DeviceKeys (useful for logging or persistence)
+// so the caller can record the device_id without recomputing it.
+func UploadImpersonatableDevice(
+	ctx context.Context,
+	signer ImpersonatorSigner,
+	uploader KeysUploader,
+	ghostUserID id.UserID,
+	bot ImpersonatorBotIdentity,
+) (*mautrix.DeviceKeys, error) {
+	if uploader == nil {
+		return nil, fmt.Errorf("keys uploader is required")
+	}
+	dk, err := BuildImpersonatableDeviceKeys(
+		signer,
+		ghostUserID, MSC4350ImpersonatableDeviceID,
+		bot.UserID, bot.DeviceID,
+		bot.SigningKey, bot.IdentityKey,
+	)
+	if err != nil {
+		return nil, err
+	}
+	if _, err := uploader.UploadKeys(ctx, &mautrix.ReqUploadKeys{DeviceKeys: dk}); err != nil {
+		return dk, fmt.Errorf("upload impersonatable device for %s: %w", ghostUserID, err)
+	}
+	return dk, nil
 }

--- a/bridgev2/matrix/impersonator_test.go
+++ b/bridgev2/matrix/impersonator_test.go
@@ -7,6 +7,7 @@
 package matrix
 
 import (
+	"context"
 	"encoding/json"
 	"strings"
 	"testing"
@@ -243,6 +244,122 @@ func TestBuildImpersonatableDeviceKeys_JSONShape(t *testing.T) {
 	}
 	if keys, _ := asMap["keys"].(map[string]any); len(keys) != 0 {
 		t.Errorf("top-level keys must serialize as {}, got %v", keys)
+	}
+}
+
+// recordingUploader is a deterministic KeysUploader that captures the
+// upload request and returns a fixed response (or a configured error).
+type recordingUploader struct {
+	lastRequest  *mautrix.ReqUploadKeys
+	respToReturn *mautrix.RespUploadKeys
+	uploadErr    error
+	callCount    int
+}
+
+func (u *recordingUploader) UploadKeys(_ context.Context, req *mautrix.ReqUploadKeys) (*mautrix.RespUploadKeys, error) {
+	u.callCount++
+	u.lastRequest = req
+	if u.uploadErr != nil {
+		return nil, u.uploadErr
+	}
+	if u.respToReturn != nil {
+		return u.respToReturn, nil
+	}
+	return &mautrix.RespUploadKeys{}, nil
+}
+
+// TestUploadImpersonatableDevice_Happy exercises the full builder +
+// upload path and confirms the request that hits the wire carries the
+// expected device keys.
+func TestUploadImpersonatableDevice_Happy(t *testing.T) {
+	signer := &recordingSigner{sigToReturn: testSignature}
+	uploader := &recordingUploader{}
+	bot := ImpersonatorBotIdentity{
+		UserID: testBotUserID, DeviceID: testBotDeviceID,
+		SigningKey: testBotSigningKey, IdentityKey: testBotIdentityKey,
+	}
+
+	dk, err := UploadImpersonatableDevice(context.Background(), signer, uploader, testGhostUserID, bot)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if dk == nil {
+		t.Fatal("expected DeviceKeys to be returned for caller bookkeeping")
+	}
+	if uploader.callCount != 1 {
+		t.Errorf("expected exactly one UploadKeys call, got %d", uploader.callCount)
+	}
+	if uploader.lastRequest == nil || uploader.lastRequest.DeviceKeys == nil {
+		t.Fatal("expected request to carry DeviceKeys")
+	}
+	if uploader.lastRequest.DeviceKeys.DeviceID != MSC4350ImpersonatableDeviceID {
+		t.Errorf("device_id should be the impersonatable constant, got %q",
+			uploader.lastRequest.DeviceKeys.DeviceID)
+	}
+	if uploader.lastRequest.DeviceKeys.UserID != testGhostUserID {
+		t.Errorf("user_id should be the GHOST, got %q",
+			uploader.lastRequest.DeviceKeys.UserID)
+	}
+	if uploader.lastRequest.OneTimeKeys != nil {
+		t.Errorf("impersonatable upload must NOT include OneTimeKeys, got %#v",
+			uploader.lastRequest.OneTimeKeys)
+	}
+}
+
+// TestUploadImpersonatableDevice_UploadError surfaces a network/HTTP
+// failure to the caller with the ghost user ID baked into the error
+// message so failures are actionable in logs.
+func TestUploadImpersonatableDevice_UploadError(t *testing.T) {
+	signer := &recordingSigner{sigToReturn: testSignature}
+	uploader := &recordingUploader{uploadErr: sentinelErr("simulated 500 from /keys/upload")}
+	bot := ImpersonatorBotIdentity{
+		UserID: testBotUserID, DeviceID: testBotDeviceID,
+		SigningKey: testBotSigningKey, IdentityKey: testBotIdentityKey,
+	}
+
+	_, err := UploadImpersonatableDevice(context.Background(), signer, uploader, testGhostUserID, bot)
+	if err == nil {
+		t.Fatal("expected error from upload to propagate, got nil")
+	}
+	if !strings.Contains(err.Error(), string(testGhostUserID)) {
+		t.Errorf("error should name the ghost user; got %v", err)
+	}
+	if !strings.Contains(err.Error(), "simulated 500") {
+		t.Errorf("error should wrap the underlying upload error; got %v", err)
+	}
+}
+
+// TestUploadImpersonatableDevice_BuildError verifies that builder errors
+// short-circuit BEFORE we send anything over the wire.
+func TestUploadImpersonatableDevice_BuildError(t *testing.T) {
+	signer := &recordingSigner{signErr: sentinelErr("signing key missing")}
+	uploader := &recordingUploader{}
+	bot := ImpersonatorBotIdentity{
+		UserID: testBotUserID, DeviceID: testBotDeviceID,
+		SigningKey: testBotSigningKey, IdentityKey: testBotIdentityKey,
+	}
+
+	_, err := UploadImpersonatableDevice(context.Background(), signer, uploader, testGhostUserID, bot)
+	if err == nil {
+		t.Fatal("expected build error to propagate")
+	}
+	if uploader.callCount != 0 {
+		t.Errorf("must not call upload when build fails; calls=%d", uploader.callCount)
+	}
+}
+
+// TestUploadImpersonatableDevice_NilUploader rejects misuse early. A
+// caller that has chosen not to wire up uploads should not be quietly
+// constructing devices that go nowhere.
+func TestUploadImpersonatableDevice_NilUploader(t *testing.T) {
+	signer := &recordingSigner{sigToReturn: testSignature}
+	bot := ImpersonatorBotIdentity{
+		UserID: testBotUserID, DeviceID: testBotDeviceID,
+		SigningKey: testBotSigningKey, IdentityKey: testBotIdentityKey,
+	}
+	_, err := UploadImpersonatableDevice(context.Background(), signer, nil, testGhostUserID, bot)
+	if err == nil {
+		t.Fatal("expected error when uploader is nil")
 	}
 }
 

--- a/bridgev2/matrix/impersonator_test.go
+++ b/bridgev2/matrix/impersonator_test.go
@@ -1,0 +1,285 @@
+// Copyright (c) 2026 Jonathan Page (benmichael)
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package matrix
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"maunium.net/go/mautrix"
+	"maunium.net/go/mautrix/id"
+)
+
+// recordingSigner is a deterministic ImpersonatorSigner that captures the
+// object it was asked to sign and returns a fixed signature string. It
+// lets us assert what was actually fed to SignJSON without depending on
+// the goolm/libolm primitives, which require deps unavailable in some
+// CI environments.
+type recordingSigner struct {
+	sigToReturn string
+	lastSigned  any
+	signErr     error
+}
+
+func (s *recordingSigner) SignJSON(obj any) (string, error) {
+	s.lastSigned = obj
+	if s.signErr != nil {
+		return "", s.signErr
+	}
+	return s.sigToReturn, nil
+}
+
+const (
+	testGhostUserID   id.UserID   = "@whatsapp_27733183724:matrix.thepages.family"
+	testGhostDeviceID id.DeviceID = MSC4350ImpersonatableDeviceID
+	testBotUserID     id.UserID   = "@whatsappbot:matrix.thepages.family"
+	testBotDeviceID   id.DeviceID = "BOTDEV01"
+
+	testBotSigningKey  id.SigningKey  = "QXFakeEd25519SigningKeyForTestPurposesOnly00"
+	testBotIdentityKey id.IdentityKey = "QXFakeCurve25519IdentityKeyForTestPurposes00"
+	testSignature                     = "BASE64ENCODEDFAKESIGNATUREVALUEFROMBOTDEV01"
+)
+
+// TestBuildImpersonatableDeviceKeys_Happy verifies the canonical happy
+// path: result has the spec-required empty algorithms/keys, the typed
+// impersonator field points at the bot, and the signature ends up keyed
+// correctly under the bot's user/device.
+func TestBuildImpersonatableDeviceKeys_Happy(t *testing.T) {
+	signer := &recordingSigner{sigToReturn: testSignature}
+
+	dk, err := BuildImpersonatableDeviceKeys(
+		signer,
+		testGhostUserID, testGhostDeviceID,
+		testBotUserID, testBotDeviceID,
+		testBotSigningKey, testBotIdentityKey,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if dk.UserID != testGhostUserID {
+		t.Errorf("UserID: got %q, want %q", dk.UserID, testGhostUserID)
+	}
+	if dk.DeviceID != testGhostDeviceID {
+		t.Errorf("DeviceID: got %q, want %q", dk.DeviceID, testGhostDeviceID)
+	}
+	if len(dk.Algorithms) != 0 {
+		t.Errorf("Algorithms MUST be empty per MSC4350, got %v", dk.Algorithms)
+	}
+	if len(dk.Keys) != 0 {
+		t.Errorf("Keys MUST be empty per MSC4350, got %v", dk.Keys)
+	}
+
+	imp := dk.MSC4350Impersonator
+	if imp == nil {
+		t.Fatal("MSC4350Impersonator must be populated")
+	}
+	if imp.UserID != testBotUserID {
+		t.Errorf("impersonator UserID: got %q, want %q", imp.UserID, testBotUserID)
+	}
+	if imp.DeviceID != testBotDeviceID {
+		t.Errorf("impersonator DeviceID: got %q, want %q", imp.DeviceID, testBotDeviceID)
+	}
+	if len(imp.Algorithms) != 2 {
+		t.Errorf("impersonator algorithms count: got %d, want 2", len(imp.Algorithms))
+	}
+	ed := imp.Keys[id.NewDeviceKeyID(id.KeyAlgorithmEd25519, testBotDeviceID)]
+	if ed != string(testBotSigningKey) {
+		t.Errorf("impersonator ed25519 key: got %q, want %q", ed, testBotSigningKey)
+	}
+	curve := imp.Keys[id.NewDeviceKeyID(id.KeyAlgorithmCurve25519, testBotDeviceID)]
+	if curve != string(testBotIdentityKey) {
+		t.Errorf("impersonator curve25519 key: got %q, want %q", curve, testBotIdentityKey)
+	}
+
+	// Signature: keyed by BOT user/device, NOT the ghost.
+	keyID := id.NewKeyID(id.KeyAlgorithmEd25519, testBotDeviceID.String())
+	gotSig, ok := dk.Signatures[testBotUserID][keyID]
+	if !ok {
+		t.Fatalf("expected signature under [%s][%s]; got Signatures=%#v",
+			testBotUserID, keyID, dk.Signatures)
+	}
+	if gotSig != testSignature {
+		t.Errorf("signature value: got %q, want %q", gotSig, testSignature)
+	}
+	if _, ghostSigned := dk.Signatures[testGhostUserID]; ghostSigned {
+		t.Errorf("ghost user MUST NOT appear in signatures map; got %#v", dk.Signatures)
+	}
+}
+
+// TestBuildImpersonatableDeviceKeys_SignedObjectIsCorrect verifies that
+// the signer is invoked on the device keys BEFORE the signatures map is
+// populated, so the signature is over a canonical form that does not
+// already contain itself.
+func TestBuildImpersonatableDeviceKeys_SignedObjectIsCorrect(t *testing.T) {
+	signer := &recordingSigner{sigToReturn: testSignature}
+
+	_, err := BuildImpersonatableDeviceKeys(
+		signer,
+		testGhostUserID, testGhostDeviceID,
+		testBotUserID, testBotDeviceID,
+		testBotSigningKey, testBotIdentityKey,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	signed, ok := signer.lastSigned.(*mautrix.DeviceKeys)
+	if !ok {
+		t.Fatalf("expected lastSigned to be *mautrix.DeviceKeys, got %T", signer.lastSigned)
+	}
+	if len(signed.Signatures) != 0 {
+		t.Errorf("device handed to signer MUST have empty Signatures, got %#v", signed.Signatures)
+	}
+
+	// The marshalled JSON sent for signing must already carry the
+	// impersonator field under its unstable prefix — otherwise the
+	// signature wouldn't bind it.
+	asJSON, err := json.Marshal(signed)
+	if err != nil {
+		t.Fatalf("re-marshal failed: %v", err)
+	}
+	if !strings.Contains(string(asJSON), `"fi.mau.msc4350.impersonator"`) {
+		t.Errorf("signed JSON missing the impersonator field; got %s", string(asJSON))
+	}
+}
+
+// TestBuildImpersonatableDeviceKeys_SignerError surfaces signer failures
+// to the caller so the bridge can choose whether to retry, log, or
+// fall back to non-MSC4350 behaviour.
+func TestBuildImpersonatableDeviceKeys_SignerError(t *testing.T) {
+	signer := &recordingSigner{signErr: errSign}
+	_, err := BuildImpersonatableDeviceKeys(
+		signer,
+		testGhostUserID, testGhostDeviceID,
+		testBotUserID, testBotDeviceID,
+		testBotSigningKey, testBotIdentityKey,
+	)
+	if err == nil {
+		t.Fatal("expected signer error to propagate, got nil")
+	}
+	if !strings.Contains(err.Error(), "sign impersonatable device") {
+		t.Errorf("error should wrap with context; got %v", err)
+	}
+}
+
+// TestBuildImpersonatableDeviceKeys_RequiredArgs guards each pre-flight
+// check independently so a future refactor can't silently drop one.
+func TestBuildImpersonatableDeviceKeys_RequiredArgs(t *testing.T) {
+	signer := &recordingSigner{sigToReturn: testSignature}
+
+	cases := []struct {
+		name string
+		mut  func(args *argSet)
+	}{
+		{"nil signer", func(a *argSet) { a.signer = nil }},
+		{"empty ghost user", func(a *argSet) { a.ghostUser = "" }},
+		{"empty ghost device", func(a *argSet) { a.ghostDevice = "" }},
+		{"empty bot user", func(a *argSet) { a.botUser = "" }},
+		{"empty bot device", func(a *argSet) { a.botDevice = "" }},
+		{"empty bot signing key", func(a *argSet) { a.botSigning = "" }},
+		{"empty bot identity key", func(a *argSet) { a.botIdentity = "" }},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			args := defaultArgs(signer)
+			tc.mut(&args)
+			_, err := BuildImpersonatableDeviceKeys(
+				args.signer,
+				args.ghostUser, args.ghostDevice,
+				args.botUser, args.botDevice,
+				args.botSigning, args.botIdentity,
+			)
+			if err == nil {
+				t.Fatalf("%s: expected error, got nil", tc.name)
+			}
+		})
+	}
+}
+
+// TestBuildImpersonatableDeviceKeys_JSONShape ensures the serialized
+// output uses the unstable JSON key (we MUST NOT ship "impersonator"
+// until MSC4350 stabilizes) and otherwise has the shape Synapse's
+// MSC4350 upload validator expects.
+func TestBuildImpersonatableDeviceKeys_JSONShape(t *testing.T) {
+	signer := &recordingSigner{sigToReturn: testSignature}
+	dk, err := BuildImpersonatableDeviceKeys(
+		signer,
+		testGhostUserID, testGhostDeviceID,
+		testBotUserID, testBotDeviceID,
+		testBotSigningKey, testBotIdentityKey,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	raw, err := json.Marshal(dk)
+	if err != nil {
+		t.Fatalf("marshal failed: %v", err)
+	}
+
+	var asMap map[string]any
+	if err := json.Unmarshal(raw, &asMap); err != nil {
+		t.Fatalf("re-unmarshal failed: %v", err)
+	}
+
+	imp, ok := asMap["fi.mau.msc4350.impersonator"].(map[string]any)
+	if !ok {
+		t.Fatalf("missing unstable impersonator key; got keys: %v", keysOf(asMap))
+	}
+	if _, hasSigs := imp["signatures"]; hasSigs {
+		t.Errorf("embedded impersonator MUST NOT have a signatures field; got %#v", imp)
+	}
+	if _, hasStable := asMap["impersonator"]; hasStable {
+		t.Errorf("stable 'impersonator' key MUST NOT be emitted while MSC4350 is unstable")
+	}
+	if algs, _ := asMap["algorithms"].([]any); len(algs) != 0 {
+		t.Errorf("top-level algorithms must serialize as [], got %v", algs)
+	}
+	if keys, _ := asMap["keys"].(map[string]any); len(keys) != 0 {
+		t.Errorf("top-level keys must serialize as {}, got %v", keys)
+	}
+}
+
+// --- helpers ---
+
+type argSet struct {
+	signer      ImpersonatorSigner
+	ghostUser   id.UserID
+	ghostDevice id.DeviceID
+	botUser     id.UserID
+	botDevice   id.DeviceID
+	botSigning  id.SigningKey
+	botIdentity id.IdentityKey
+}
+
+func defaultArgs(s ImpersonatorSigner) argSet {
+	return argSet{
+		signer:      s,
+		ghostUser:   testGhostUserID,
+		ghostDevice: testGhostDeviceID,
+		botUser:     testBotUserID,
+		botDevice:   testBotDeviceID,
+		botSigning:  testBotSigningKey,
+		botIdentity: testBotIdentityKey,
+	}
+}
+
+func keysOf(m map[string]any) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}
+
+type sentinelErr string
+
+func (e sentinelErr) Error() string { return string(e) }
+
+const errSign sentinelErr = "deliberate signer failure for test"

--- a/bridgev2/matrix/intent.go
+++ b/bridgev2/matrix/intent.go
@@ -82,6 +82,25 @@ func (as *ASIntent) SendMessage(ctx context.Context, roomID id.RoomID, eventType
 					as.Matrix.AddDoublePuppetValueWithTS(content, extra.Timestamp.UnixMilli())
 				}
 			}
+			// MSC4350: ensure the ghost has an impersonatable device on
+			// the server before we encrypt anything as them. Skipped for
+			// the bot itself (it IS the impersonator) and for
+			// double-puppeted real users (DP gets opt-in support later).
+			// A failure here is logged but not fatal - without MSC4350
+			// the sender-mismatch warning resurfaces, but the message
+			// still gets through.
+			if !as.Matrix.IsCustomPuppet && as.Matrix.UserID != as.Connector.AS.BotMXID() {
+				if msc4350Helper, ok := as.Connector.Crypto.(interface {
+					EnsureImpersonatableDevice(context.Context, id.UserID) error
+				}); ok {
+					if ensureErr := msc4350Helper.EnsureImpersonatableDevice(ctx, as.Matrix.UserID); ensureErr != nil {
+						zerolog.Ctx(ctx).Warn().
+							Err(ensureErr).
+							Stringer("ghost", as.Matrix.UserID).
+							Msg("Failed to ensure MSC4350 impersonatable device; continuing with encryption")
+					}
+				}
+			}
 			err = as.Connector.Crypto.Encrypt(ctx, roomID, eventType, content)
 			if err != nil {
 				return nil, err

--- a/bridgev2/matrix/intent.go
+++ b/bridgev2/matrix/intent.go
@@ -89,31 +89,16 @@ func (as *ASIntent) SendMessage(ctx context.Context, roomID id.RoomID, eventType
 			// A failure here is logged but not fatal - without MSC4350
 			// the sender-mismatch warning resurfaces, but the message
 			// still gets through.
-			// MSC4350 debug instrumentation (temporary - revert before
-			// upstreaming): unconditionally log when we hit the hook so we
-			// can confirm code-path coverage in production logs without
-			// turning on bridge-wide DEBUG.
-			zerolog.Ctx(ctx).Info().
-				Stringer("ghost", as.Matrix.UserID).
-				Bool("is_custom_puppet", as.Matrix.IsCustomPuppet).
-				Stringer("bot_mxid", as.Connector.AS.BotMXID()).
-				Msg("MSC4350 hook reached")
 			if !as.Matrix.IsCustomPuppet && as.Matrix.UserID != as.Connector.AS.BotMXID() {
 				if msc4350Helper, ok := as.Connector.Crypto.(interface {
 					EnsureImpersonatableDevice(context.Context, id.UserID) error
 				}); ok {
-					zerolog.Ctx(ctx).Info().
-						Stringer("ghost", as.Matrix.UserID).
-						Msg("MSC4350 calling EnsureImpersonatableDevice")
 					if ensureErr := msc4350Helper.EnsureImpersonatableDevice(ctx, as.Matrix.UserID); ensureErr != nil {
 						zerolog.Ctx(ctx).Warn().
 							Err(ensureErr).
 							Stringer("ghost", as.Matrix.UserID).
 							Msg("Failed to ensure MSC4350 impersonatable device; continuing with encryption")
 					}
-				} else {
-					zerolog.Ctx(ctx).Warn().
-						Msg("MSC4350 interface assertion failed - Crypto type does not have EnsureImpersonatableDevice")
 				}
 			}
 			err = as.Connector.Crypto.Encrypt(ctx, roomID, eventType, content)

--- a/bridgev2/matrix/intent.go
+++ b/bridgev2/matrix/intent.go
@@ -89,16 +89,31 @@ func (as *ASIntent) SendMessage(ctx context.Context, roomID id.RoomID, eventType
 			// A failure here is logged but not fatal - without MSC4350
 			// the sender-mismatch warning resurfaces, but the message
 			// still gets through.
+			// MSC4350 debug instrumentation (temporary - revert before
+			// upstreaming): unconditionally log when we hit the hook so we
+			// can confirm code-path coverage in production logs without
+			// turning on bridge-wide DEBUG.
+			zerolog.Ctx(ctx).Info().
+				Stringer("ghost", as.Matrix.UserID).
+				Bool("is_custom_puppet", as.Matrix.IsCustomPuppet).
+				Stringer("bot_mxid", as.Connector.AS.BotMXID()).
+				Msg("MSC4350 hook reached")
 			if !as.Matrix.IsCustomPuppet && as.Matrix.UserID != as.Connector.AS.BotMXID() {
 				if msc4350Helper, ok := as.Connector.Crypto.(interface {
 					EnsureImpersonatableDevice(context.Context, id.UserID) error
 				}); ok {
+					zerolog.Ctx(ctx).Info().
+						Stringer("ghost", as.Matrix.UserID).
+						Msg("MSC4350 calling EnsureImpersonatableDevice")
 					if ensureErr := msc4350Helper.EnsureImpersonatableDevice(ctx, as.Matrix.UserID); ensureErr != nil {
 						zerolog.Ctx(ctx).Warn().
 							Err(ensureErr).
 							Stringer("ghost", as.Matrix.UserID).
 							Msg("Failed to ensure MSC4350 impersonatable device; continuing with encryption")
 					}
+				} else {
+					zerolog.Ctx(ctx).Warn().
+						Msg("MSC4350 interface assertion failed - Crypto type does not have EnsureImpersonatableDevice")
 				}
 			}
 			err = as.Connector.Crypto.Encrypt(ctx, roomID, eventType, content)

--- a/bridgev2/matrix/mxmain/example-config.yaml
+++ b/bridgev2/matrix/mxmain/example-config.yaml
@@ -412,6 +412,14 @@ encryption:
     # Requires the homeserver to support MSC4190 and the device masquerading parts of MSC3202.
     # Only relevant when using end-to-bridge encryption, required when using encryption with next-gen auth (MSC3861).
     msc4190: false
+    # Whether to use MSC4350 to legitimize the bridge bot's device signing
+    # events on behalf of ghost users (and double-puppeted real users), so
+    # recipient clients no longer flag bridged events with "sender doesn't
+    # match device owner" warnings.
+    # Requires the homeserver to support MSC4350 (synapse: experimental_features.msc4350_enabled)
+    # and a cross-signed bridge bot device (encryption.self_sign).
+    # See https://github.com/matrix-org/matrix-spec-proposals/pull/4350
+    msc4350: false
     # Whether to encrypt reactions and reply metadata as per MSC4392.
     # This is not supported by most clients.
     msc4392: false

--- a/requests.go
+++ b/requests.go
@@ -297,6 +297,26 @@ type ReqKeysSignatures struct {
 
 type ReqUploadSignatures map[id.UserID]map[string]ReqKeysSignatures
 
+// MSC4350ImpersonatorDeviceKey is the JSON object key for the
+// MSC4350 impersonator field. The unstable prefix MUST be used until
+// the spec is accepted; see
+// https://github.com/matrix-org/matrix-spec-proposals/pull/4350
+const MSC4350ImpersonatorDeviceKey = "fi.mau.msc4350.impersonator"
+
+// ImpersonatorDevice is the embedded device-keys-like object that
+// identifies which device is allowed to cryptographically impersonate
+// the owner of an impersonatable device, per MSC4350.
+//
+// Note: signatures live on the *parent* DeviceKeys, not here. Per spec,
+// the impersonator entry is the canonical device-keys object minus its
+// own signatures.
+type ImpersonatorDevice struct {
+	UserID     id.UserID      `json:"user_id"`
+	DeviceID   id.DeviceID    `json:"device_id"`
+	Algorithms []id.Algorithm `json:"algorithms"`
+	Keys       KeyMap         `json:"keys"`
+}
+
 type DeviceKeys struct {
 	UserID     id.UserID             `json:"user_id"`
 	DeviceID   id.DeviceID           `json:"device_id"`
@@ -305,7 +325,16 @@ type DeviceKeys struct {
 	Signatures signatures.Signatures `json:"signatures"`
 	Dehydrated bool                  `json:"dehydrated,omitempty"`
 	Unsigned   map[string]any        `json:"unsigned,omitempty"`
-	Extra      map[string]any        `json:"-"`
+	// MSC4350Impersonator, when non-nil, marks this device as an
+	// "impersonatable" device whose encryption operations are delegated
+	// to the bridge bot's device identified here. The owning device's
+	// Algorithms MUST be empty and Keys MUST be empty whenever this is
+	// set, and Signatures MUST contain a signature from the impersonator
+	// keyed by "ed25519:<impersonator.DeviceID>".
+	// Marshals to / unmarshals from the unstable JSON key
+	// "fi.mau.msc4350.impersonator". See MSC4350.
+	MSC4350Impersonator *ImpersonatorDevice `json:"fi.mau.msc4350.impersonator,omitempty"`
+	Extra               map[string]any      `json:"-"`
 }
 
 type serializableDeviceKeys DeviceKeys
@@ -321,6 +350,10 @@ func (dk *DeviceKeys) deleteStandardExtraFields() {
 	delete(dk.Extra, "signatures")
 	delete(dk.Extra, "dehydrated")
 	delete(dk.Extra, "unsigned")
+	// MSC4350: the impersonator field is captured by the typed
+	// MSC4350Impersonator field, so drop the raw copy in Extra to
+	// avoid double-encoding on marshal.
+	delete(dk.Extra, MSC4350ImpersonatorDeviceKey)
 }
 
 func (dk *DeviceKeys) MarshalJSON() ([]byte, error) {

--- a/requests_msc4350_test.go
+++ b/requests_msc4350_test.go
@@ -1,0 +1,156 @@
+// Copyright (c) 2026 Jonathan Page (benmichael)
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package mautrix
+
+import (
+	"encoding/json"
+	"testing"
+
+	"maunium.net/go/mautrix/id"
+)
+
+// TestDeviceKeys_MSC4350Roundtrip verifies that the MSC4350 impersonator
+// field round-trips through JSON marshal/unmarshal, accessible via the
+// typed MSC4350Impersonator pointer, with no duplication in Extra.
+func TestDeviceKeys_MSC4350Roundtrip(t *testing.T) {
+	original := DeviceKeys{
+		UserID:     "@whatsapp_27:example.org",
+		DeviceID:   "GHOSTDEV",
+		Algorithms: []id.Algorithm{}, // empty per spec
+		Keys:       KeyMap{},         // empty per spec
+		Signatures: map[id.UserID]map[id.KeyID]string{
+			"@whatsappbot:example.org": {
+				"ed25519:BOTDEV": "<sig-from-bot-device>",
+			},
+		},
+		MSC4350Impersonator: &ImpersonatorDevice{
+			UserID:   "@whatsappbot:example.org",
+			DeviceID: "BOTDEV",
+			Algorithms: []id.Algorithm{
+				"m.olm.v1.curve25519-aes-sha2",
+				"m.megolm.v1.aes-sha2",
+			},
+			Keys: KeyMap{
+				"curve25519:BOTDEV": "<bot-curve25519>",
+				"ed25519:BOTDEV":    "<bot-ed25519>",
+			},
+		},
+	}
+
+	data, err := json.Marshal(&original)
+	if err != nil {
+		t.Fatalf("marshal failed: %v", err)
+	}
+
+	// The unstable prefix must appear in the serialized JSON, not the
+	// stable name. If this fails, we shipped a violation of MSC4350's
+	// "Unstable prefix" section.
+	asMap := map[string]any{}
+	if err := json.Unmarshal(data, &asMap); err != nil {
+		t.Fatalf("re-unmarshal-as-map failed: %v", err)
+	}
+	if _, ok := asMap["fi.mau.msc4350.impersonator"]; !ok {
+		t.Errorf("expected serialized JSON to contain unstable key %q, got %s",
+			"fi.mau.msc4350.impersonator", string(data))
+	}
+	if _, ok := asMap["impersonator"]; ok {
+		t.Errorf("serialized JSON must NOT contain stable %q key "+
+			"until spec is accepted; got %s", "impersonator", string(data))
+	}
+
+	var roundTripped DeviceKeys
+	if err := json.Unmarshal(data, &roundTripped); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+
+	if roundTripped.MSC4350Impersonator == nil {
+		t.Fatal("expected MSC4350Impersonator to be populated after round-trip")
+	}
+	if got, want := roundTripped.MSC4350Impersonator.UserID, original.MSC4350Impersonator.UserID; got != want {
+		t.Errorf("impersonator UserID: got %q, want %q", got, want)
+	}
+	if got, want := roundTripped.MSC4350Impersonator.DeviceID, original.MSC4350Impersonator.DeviceID; got != want {
+		t.Errorf("impersonator DeviceID: got %q, want %q", got, want)
+	}
+	if got, want := len(roundTripped.MSC4350Impersonator.Algorithms), 2; got != want {
+		t.Errorf("impersonator Algorithms count: got %d, want %d", got, want)
+	}
+	if _, ok := roundTripped.MSC4350Impersonator.Keys["ed25519:BOTDEV"]; !ok {
+		t.Errorf("impersonator Keys missing ed25519:BOTDEV; got %v", roundTripped.MSC4350Impersonator.Keys)
+	}
+
+	// Extra must not contain a duplicate of the impersonator field —
+	// that would cause double-encoding on the next marshal.
+	if _, dup := roundTripped.Extra["fi.mau.msc4350.impersonator"]; dup {
+		t.Error("Extra should not contain a duplicate of the impersonator field after unmarshal")
+	}
+}
+
+// TestDeviceKeys_MSC4350Absent verifies the impersonator field is omitted
+// from serialized JSON when not set, so we don't accidentally announce
+// MSC4350 support for vanilla bridge bot devices.
+func TestDeviceKeys_MSC4350Absent(t *testing.T) {
+	dk := DeviceKeys{
+		UserID:     "@whatsappbot:example.org",
+		DeviceID:   "BOTDEV",
+		Algorithms: []id.Algorithm{"m.olm.v1.curve25519-aes-sha2"},
+		Keys: KeyMap{
+			"curve25519:BOTDEV": "<curve>",
+			"ed25519:BOTDEV":    "<ed>",
+		},
+		Signatures: map[id.UserID]map[id.KeyID]string{
+			"@whatsappbot:example.org": {"ed25519:BOTDEV": "<sig>"},
+		},
+	}
+
+	data, err := json.Marshal(&dk)
+	if err != nil {
+		t.Fatalf("marshal failed: %v", err)
+	}
+	asMap := map[string]any{}
+	if err := json.Unmarshal(data, &asMap); err != nil {
+		t.Fatalf("re-unmarshal-as-map failed: %v", err)
+	}
+	if _, present := asMap["fi.mau.msc4350.impersonator"]; present {
+		t.Errorf("impersonator field must be omitted when nil; got %s", string(data))
+	}
+}
+
+// TestDeviceKeys_MSC4350ExtraFieldsPreserved verifies that other unknown
+// fields (which the bridge framework relies on via the Extra map) still
+// flow through after the impersonator-field addition.
+func TestDeviceKeys_MSC4350ExtraFieldsPreserved(t *testing.T) {
+	input := []byte(`{
+		"user_id": "@whatsapp_27:example.org",
+		"device_id": "GHOSTDEV",
+		"algorithms": [],
+		"keys": {},
+		"signatures": {},
+		"fi.mau.msc4350.impersonator": {
+			"user_id": "@whatsappbot:example.org",
+			"device_id": "BOTDEV",
+			"algorithms": ["m.olm.v1.curve25519-aes-sha2"],
+			"keys": {"ed25519:BOTDEV": "<key>"}
+		},
+		"some.unknown.extension": {"hello": "world"}
+	}`)
+
+	var dk DeviceKeys
+	if err := json.Unmarshal(input, &dk); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+	if dk.MSC4350Impersonator == nil {
+		t.Fatal("expected MSC4350Impersonator to be populated")
+	}
+	if dk.Extra == nil || dk.Extra["some.unknown.extension"] == nil {
+		t.Errorf("Extra map should contain unknown fields; got %#v", dk.Extra)
+	}
+	// Confirm we DON'T duplicate the typed field in Extra:
+	if _, dup := dk.Extra["fi.mau.msc4350.impersonator"]; dup {
+		t.Error("Extra must not contain a duplicate of the typed impersonator field")
+	}
+}


### PR DESCRIPTION
**Status:** Draft, scaffolding only — sprint 1 of a longer implementation effort. Not yet ready for review.

## What this PR does
Adds an `encryption.msc4350` config flag (default `false`) that will gate the bridge-side implementation of [MSC4350: Permitting encryption impersonation for appservices](https://github.com/matrix-org/matrix-spec-proposals/pull/4350).

This commit only introduces the flag and its docstring in the canonical example config. No behaviour changes; with the flag off (the default), the bridge behaves exactly as today.

## Why MSC4350
Currently mautrix bridges sign all encrypted events with a single bridge bot device regardless of which ghost is the event sender. Under MSC4153 (Invisible Crypto), strict clients are starting to refuse such events, and Element already warns "The sender of the event does not match the owner of the device that sent it." MSC4350 legitimizes the pattern via an `impersonator` field on the ghost's device entry.

## Roadmap
Subsequent commits on this branch will add, in this order:

1. Extend the `id.DeviceKeys` model to serialize / deserialize the unstable `fi.mau.msc4350.impersonator` field.
2. In `bridgev2/matrix/crypto.go`, after the bridge bot device is created and cross-signed, ensure each ghost user has an impersonatable device pointing at the bot via MSC4326 device masquerading.
3. Double-puppet variant: similar but additionally signed by the user's self-signing key. Requires user interaction or recovery key — gated separately.
4. Tests.

Companion synapse work: https://github.com/element-hq/synapse/pull/19827

## Engagement
@tulir — opening this draft to anchor the work and stay aligned with your direction. If you'd prefer to implement MSC4350 yourself, or have a different architecture in mind than what's outlined in the roadmap, please let me know **before** I write more code; I'd rather adapt now than duplicate effort. Otherwise I'll keep moving and ping again when there's substantive behaviour to review.

## Related
- MSC4350 spec: matrix-org/matrix-spec-proposals#4350
- MSC4153 invisible crypto: matrix-org/matrix-spec-proposals#4153
- MSC4326 device masquerading, now stable in synapse: element-hq/synapse#19033
