### PR TITLE
bridgev2/matrix: retry direct media downloads to fix send-before-insert race

### DIFF
--- a/bridgev2/matrix/directmedia.go
+++ b/bridgev2/matrix/directmedia.go
@@ -14,6 +14,9 @@ import (
 	"encoding/base64"
 	"fmt"
 	"strings"
+	"time"
+
+	"github.com/rs/zerolog"
 
 	"maunium.net/go/mautrix"
 	"maunium.net/go/mautrix/bridgev2"
@@ -25,6 +28,27 @@ import (
 const MediaIDPrefix = "\U0001F408"
 const MediaIDTruncatedHashLength = 16
 const ContentURIMaxLength = 255
+
+// Direct media downloads can race with message persistence: bridgev2's
+// sendConvertedMessage (portal.go) sends the Matrix event via intent.SendMessage
+// *before* inserting the message row into the database (the row needs the MXID
+// returned by the send, so the order can't be flipped). With a local bridge the
+// Matrix client may auto-download the generated mxc:// URI within milliseconds of
+// the send, before the connector has stored the message row. The connector's
+// Download then can't find the message and returns an error, which the media proxy
+// surfaces to the client as a terminal "not found" (the iOS "Something went wrong").
+//
+// To paper over that narrow race we retry the connector Download a bounded number
+// of times. Connectors signal "message not found" inconsistently (e.g. the Meta
+// connector returns a plain fmt.Errorf("message not found")), so there is no
+// reliable typed/sentinel not-found error to scope the retry to at this layer.
+// We therefore retry on any error; the cost is at most ~directMediaRetryMax *
+// directMediaRetryDelay of added latency on the genuine-failure path, which is
+// acceptable since these requests are already failing.
+const (
+	directMediaRetryMax   = 10
+	directMediaRetryDelay = 200 * time.Millisecond
+)
 
 func (br *Connector) initDirectMedia() error {
 	if !br.Config.DirectMedia.Enabled {
@@ -103,5 +127,22 @@ func (br *Connector) getDirectMedia(ctx context.Context, mediaIDStr string, para
 	if err != nil {
 		return response, err
 	}
-	return br.Bridge.Network.(bridgev2.DirectMediableNetwork).Download(ctx, remoteMediaID, params)
+	dmn := br.Bridge.Network.(bridgev2.DirectMediableNetwork)
+	// Retry the download briefly to work around the send-before-insert race in
+	// bridgev2's sendConvertedMessage (see the directMediaRetry* doc comment above).
+	for attempt := 0; ; attempt++ {
+		response, err = dmn.Download(ctx, remoteMediaID, params)
+		if err == nil || attempt >= directMediaRetryMax {
+			return response, err
+		}
+		zerolog.Ctx(ctx).Debug().Err(err).
+			Int("attempt", attempt+1).
+			Int("max_attempts", directMediaRetryMax+1).
+			Msg("Direct media download failed, retrying in case message is not yet persisted")
+		select {
+		case <-time.After(directMediaRetryDelay):
+		case <-ctx.Done():
+			return response, ctx.Err()
+		}
+	}
 }


### PR DESCRIPTION
## Problem

`bridgev2`'s `sendConvertedMessage` (in `bridgev2/portal.go`) sends the Matrix event via `intent.SendMessage` **before** persisting the message row via `portal.Bridge.DB.Message.Insert`. The ordering can't be flipped, because the DB row's MXID comes from the send response (`dbMessage.MXID = resp.EventID`).

With an in-process **local bridge**, the Matrix client auto-downloads the generated `mxc://` (`localmxc://`) media within milliseconds of the send — before the connector has inserted the message row. The connector's `Download` then can't find the message and returns an error, which the media proxy surfaces to the client as a terminal not-found. On iOS this shows up as "Something went wrong".

## Fix

Add a **bounded wait/retry** at the SDK level in `getDirectMedia` (`bridgev2/matrix/directmedia.go`) — the single chokepoint that all direct-media downloads flow through. A request that arrives in the race window retries briefly (11 attempts, ~200ms apart, ~2s max) instead of failing hard, and respects `ctx` cancellation (`select` on `ctx.Done()` vs `time.After`).

Fixing it here rather than in an individual connector means **all connectors** benefit, not just Meta.

### Why retry on any error

Connectors signal "message not found" inconsistently (e.g. the Meta connector returns a plain `fmt.Errorf("message not found")`), so there is no reliable typed/sentinel not-found error to scope the retry to at this layer. The retry is therefore on any error; the only added cost is ~2s of latency on the genuine-failure path, which is acceptable since those requests are already failing. This is documented in a code comment.

`sendConvertedMessage`'s ordering is intentionally left unchanged.

## Supersedes

This replaces the closed connector-level PR mautrix/meta#281, which patched only the Meta connector. The SDK-level fix here is the correct, generic location per the ticket.

Linear: https://linear.app/beeper/issue/BIOS-32186

🤖 Generated with [Claude Code](https://claude.com/claude-code)