### PR TITLE
portalbackfill: keep never-bridged messages in forward backfill dedup

### DIFF
--- a/bridgev2/portalbackfill.go
+++ b/bridgev2/portalbackfill.go
@@ -249,10 +249,8 @@ func (portal *Portal) cutoffMessages(ctx context.Context, messages []*BackfillMe
 		return messages
 	}
 	if forward && !aggressiveDedup {
-		// Without aggressive dedup, trim the contiguous prefix of messages at or older than the anchor.
 		// With aggressive dedup, the ID-based pass below decides what's already bridged, so this
-		// timestamp prefix-trim is skipped to preserve never-bridged messages older than the anchor
-		// (e.g. mid-timeline gaps left when a reconnect snapshot advanced the cursor past them).
+		// timestamp prefix-trim is skipped.
 		cutoff := -1
 		for i, msg := range messages {
 			if msg.ID == lastMessage.ID || msg.Timestamp.Before(lastMessage.Timestamp) {

--- a/bridgev2/portalbackfill.go
+++ b/bridgev2/portalbackfill.go
@@ -248,7 +248,11 @@ func (portal *Portal) cutoffMessages(ctx context.Context, messages []*BackfillMe
 	if lastMessage == nil {
 		return messages
 	}
-	if forward {
+	if forward && !aggressiveDedup {
+		// Without aggressive dedup, trim the contiguous prefix of messages at or older than the anchor.
+		// With aggressive dedup, the ID-based pass below decides what's already bridged, so this
+		// timestamp prefix-trim is skipped to preserve never-bridged messages older than the anchor
+		// (e.g. mid-timeline gaps left when a reconnect snapshot advanced the cursor past them).
 		cutoff := -1
 		for i, msg := range messages {
 			if msg.ID == lastMessage.ID || msg.Timestamp.Before(lastMessage.Timestamp) {
@@ -265,7 +269,7 @@ func (portal *Portal) cutoffMessages(ctx context.Context, messages []*BackfillMe
 				Msg("Cutting off forward backfill messages older than latest bridged message")
 			messages = messages[cutoff+1:]
 		}
-	} else {
+	} else if !forward {
 		cutoff := -1
 		for i := len(messages) - 1; i >= 0; i-- {
 			if messages[i].ID == lastMessage.ID || messages[i].Timestamp.After(lastMessage.Timestamp) {


### PR DESCRIPTION
See https://github.com/mautrix/meta/pull/286

But basically - aggressive dupe should probably not do prefix deleting as it breaks the "check each message" approach, which in meta's case can lead to permanently lost messages.
