### PR TITLE
event/capabilities: add more details for polls

### DIFF
--- a/event/capabilities.d.ts
+++ b/event/capabilities.d.ts
@@ -41,6 +41,16 @@ export interface RoomFeatures {
 	location_message?: CapabilitySupportLevel
 	/** Whether polls are supported. */
 	poll?: CapabilitySupportLevel
+	/** Whether ending (closing) a poll is supported. */
+	poll_end?: CapabilitySupportLevel
+	/** Whether polls with hidden votes are supported. */
+	poll_hidden_votes?: CapabilitySupportLevel
+	/** Whether a poll may contain options with duplicate text. If unsupported, options must be unique. */
+	poll_duplicate_options?: CapabilitySupportLevel
+	/** Maximum number of options a poll may have. 0 or omitted means no limit. */
+	poll_max_options?: number
+	/** Maximum length of a single poll option in characters. 0 or omitted means no limit. */
+	poll_option_max_length?: number
 	/** Whether replying in a thread is supported. */
 	thread?: CapabilitySupportLevel
 	/** Whether replying to a specific message is supported. */

--- a/event/capabilities.go
+++ b/event/capabilities.go
@@ -36,9 +36,16 @@ type RoomFeatures struct {
 	MaxTextLength int `json:"max_text_length,omitempty"`
 
 	LocationMessage CapabilitySupportLevel `json:"location_message,omitempty"`
-	Poll            CapabilitySupportLevel `json:"poll,omitempty"`
-	Thread          CapabilitySupportLevel `json:"thread,omitempty"`
-	Reply           CapabilitySupportLevel `json:"reply,omitempty"`
+
+	Poll                 CapabilitySupportLevel `json:"poll,omitempty"`
+	PollEnd              CapabilitySupportLevel `json:"poll_end,omitempty"`
+	PollHiddenVotes      CapabilitySupportLevel `json:"poll_hidden_votes,omitempty"`
+	PollDuplicateOptions CapabilitySupportLevel `json:"poll_duplicate_options,omitempty"`
+	PollMaxOptions       int                    `json:"poll_max_options,omitempty"`
+	PollOptionMaxLength  int                    `json:"poll_option_max_length,omitempty"`
+
+	Thread CapabilitySupportLevel `json:"thread,omitempty"`
+	Reply  CapabilitySupportLevel `json:"reply,omitempty"`
 
 	Edit         CapabilitySupportLevel `json:"edit,omitempty"`
 	EditMaxCount int                    `json:"edit_max_count,omitempty"`
@@ -344,6 +351,11 @@ func (rf *RoomFeatures) Hash() []byte {
 
 	hashValue(hasher, "location_message", rf.LocationMessage)
 	hashValue(hasher, "poll", rf.Poll)
+	hashValue(hasher, "poll_end", rf.PollEnd)
+	hashValue(hasher, "poll_hidden_votes", rf.PollHiddenVotes)
+	hashValue(hasher, "poll_duplicate_options", rf.PollDuplicateOptions)
+	hashInt(hasher, "poll_max_options", rf.PollMaxOptions)
+	hashInt(hasher, "poll_option_max_length", rf.PollOptionMaxLength)
 	hashValue(hasher, "thread", rf.Thread)
 	hashValue(hasher, "reply", rf.Reply)
 


### PR DESCRIPTION
```
         /** Whether ending (closing) a poll is supported. */
	poll_end?: CapabilitySupportLevel
	/** Whether polls with hidden votes are supported. */
	poll_hidden_votes?: CapabilitySupportLevel
	/** Whether a poll may contain options with duplicate text. If unsupported, options must be unique. */
	poll_duplicate_options?: CapabilitySupportLevel
	/** Maximum number of options a poll may have. 0 or omitted means no limit. */
	poll_max_options?: number
	/** Maximum length of a single poll option in characters. 0 or omitted means no limit. */
	poll_option_max_length?: number
```

Maybe `poll_option_max_length` could be left out 

### Checklist

* [x] I have read and followed the contributing guidelines at <https://docs.mau.fi/bridges/general/contributing.html>
