### PR TITLE
oauth: Add optional Scope field to TokenResponse

### DIFF
--- a/oauth/types.go
+++ b/oauth/types.go
@@ -143,6 +143,7 @@ type TokenResponse struct {
 	TokenType    string           `json:"token_type"`
 	ExpiresIn    jsontime.Seconds `json:"expires_in"`
 	RefreshToken string           `json:"refresh_token,omitempty"`
+	Scope        Scope            `json:"scope,omitempty"`
 }
 
 type ScopeList []Scope

--- a/oauth/types.go
+++ b/oauth/types.go
@@ -138,12 +138,18 @@ type ClientMetadata struct {
 	Extra map[string]any `json:",unknown"`
 }
 
+type ScopeGroup string
+
+func (sg ScopeGroup) Split() []Scope {
+	return exslices.CastToString[Scope](strings.Split(string(sg), " "))
+}
+
 type TokenResponse struct {
 	AccessToken  string           `json:"access_token"`
 	TokenType    string           `json:"token_type"`
 	ExpiresIn    jsontime.Seconds `json:"expires_in"`
 	RefreshToken string           `json:"refresh_token,omitempty"`
-	Scope        Scope            `json:"scope,omitempty"`
+	Scope        ScopeGroup       `json:"scope,omitempty"`
 }
 
 type ScopeList []Scope


### PR DESCRIPTION
https://datatracker.ietf.org/doc/html/rfc6749#section-5.1 - `scope` is REQUIRED if the server returns a scope differing from the client's request

### Checklist

* [x] I have read and followed the contributing guidelines at <https://docs.mau.fi/bridges/general/contributing.html>
