### PR TITLE
bridgev2/portal: don't fail message handling when the event is already bridged

### DIFF
--- a/bridgev2/portal.go
+++ b/bridgev2/portal.go
@@ -2931,6 +2931,15 @@ func (portal *Portal) sendConvertedMessage(
 		}
 		err := portal.Bridge.DB.Message.Insert(ctx, dbMessage)
 		if err != nil {
+			existing, dupErr := portal.Bridge.DB.Message.GetPartByMXID(ctx, dbMessage.MXID)
+			if dupErr == nil && existing != nil {
+				logContext(log.Warn()).
+					Str("part_id", string(part.ID)).
+					Stringer("event_id", dbMessage.MXID).
+					Str("existing_message_id", string(existing.ID)).
+					Msg("Message part is already bridged under a different ID, not saving again")
+				continue
+			}
 			logContext(log.Err(err)).Str("part_id", string(part.ID)).Msg("Failed to save message part to database")
 			errorList = append(errorList, fmt.Errorf("%w: failed to save message part to database: %w", ErrDatabaseError, err))
 		}


### PR DESCRIPTION
When a connector re-IDs an existing message row (mautrix-signal does this on edits, pointing the row at the edit's timestamp so chained edit targets resolve), a redelivery of the original network message misses the duplicate check in `handleRemoteMessage`, which keys on the network ID.

With an intent that generates deterministic event IDs the resend then returns the row's existing mxid, so the insert dies on `message_mxid_unique` and the whole remote event is reported as failed — on Signal that means the envelope is never acked and the receive queue stays wedged until re-link.

This treats an insert conflicting with an existing row for the same mxid as an already-handled duplicate instead of a database error.
