### PR TITLE
bridgev2: add configurable debounce for transient connection states

### DIFF
--- a/bridgev2/bridgeconfig/config.go
+++ b/bridgev2/bridgeconfig/config.go
@@ -73,6 +73,7 @@ type BridgeConfig struct {
 	ResendBridgeInfo              bool               `yaml:"resend_bridge_info"`
 	NoBridgeInfoStateKey          bool               `yaml:"no_bridge_info_state_key"`
 	BridgeStatusNotices           string             `yaml:"bridge_status_notices"`
+	TransientStateDebounce        time.Duration      `yaml:"transient_state_debounce"`
 	UnknownErrorAutoReconnect     time.Duration      `yaml:"unknown_error_auto_reconnect"`
 	UnknownErrorMaxAutoReconnects int                `yaml:"unknown_error_max_auto_reconnects"`
 	BridgeMatrixLeave             bool               `yaml:"bridge_matrix_leave"`

--- a/bridgev2/bridgeconfig/upgrade.go
+++ b/bridgev2/bridgeconfig/upgrade.go
@@ -32,6 +32,7 @@ func doUpgrade(helper up.Helper) {
 	helper.Copy(up.Bool, "bridge", "resend_bridge_info")
 	helper.Copy(up.Bool, "bridge", "no_bridge_info_state_key")
 	helper.Copy(up.Str|up.Null, "bridge", "bridge_status_notices")
+	helper.Copy(up.Str|up.Int|up.Null, "bridge", "transient_state_debounce")
 	helper.Copy(up.Str|up.Int|up.Null, "bridge", "unknown_error_auto_reconnect")
 	helper.Copy(up.Int, "bridge", "unknown_error_max_auto_reconnects")
 	helper.Copy(up.Bool, "bridge", "bridge_matrix_leave")

--- a/bridgev2/bridgestate.go
+++ b/bridgev2/bridgestate.go
@@ -99,8 +99,43 @@ func (bsq *BridgeStateQueue) loop() {
 			}
 		}()
 	}
-	for state := range bsq.ch {
+	for rawState := range bsq.ch {
+		state, ok := bsq.debounceTransientState(rawState)
+		if !ok {
+			return
+		}
 		bsq.immediateSendBridgeState(state)
+	}
+}
+
+func isTransientState(evt status.BridgeStateEvent) bool {
+	return evt == status.StateTransientDisconnect || evt == status.StateConnecting
+}
+
+func (bsq *BridgeStateQueue) debounceTransientState(state status.BridgeState) (status.BridgeState, bool) {
+	debounce := bsq.bridge.Config.TransientStateDebounce
+	if debounce <= 0 || !isTransientState(state.StateEvent) {
+		return state, true
+	}
+	timer := time.NewTimer(debounce)
+	defer timer.Stop()
+	for {
+		select {
+		case next, ok := <-bsq.ch:
+			if !ok {
+				return state, false
+			} else if !isTransientState(next.StateEvent) {
+				bsq.login.Log.Debug().
+					Str("state_event", string(next.StateEvent)).
+					Msg("Dropping debounced state superseded within the debounce period")
+				return next, true
+			}
+			state = next
+		case <-timer.C:
+			return state, true
+		case <-bsq.stopChan:
+			return state, false
+		}
 	}
 }
 

--- a/bridgev2/matrix/mxmain/example-config.yaml
+++ b/bridgev2/matrix/mxmain/example-config.yaml
@@ -26,11 +26,8 @@ bridge:
     # These contain the same data that can be posted to an external HTTP server using homeserver -> status_endpoint.
     # Allowed values: none, errors, all
     bridge_status_notices: errors
-    # How long should TRANSIENT_DISCONNECT and CONNECTING states be held back before being
-    # reported? Most disconnects recover within a couple of seconds, and debouncing means a
-    # login that drops and reconnects within the delay reports no state changes at all.
-    # Whatever state the login is in when the delay passes is reported as normal, and errors
-    # are never delayed. 0s disables the debounce.
+    # How long should TRANSIENT_DISCONNECT and CONNECTING states be held back before being reported?
+    # If another state update occurs while waiting, the previous state won't be reported at all.
     transient_state_debounce: 0s
     # How long after an unknown error should the bridge attempt a full reconnect?
     # Must be at least 1 minute. The bridge will add an extra ±20% jitter to this value.

--- a/bridgev2/matrix/mxmain/example-config.yaml
+++ b/bridgev2/matrix/mxmain/example-config.yaml
@@ -26,6 +26,12 @@ bridge:
     # These contain the same data that can be posted to an external HTTP server using homeserver -> status_endpoint.
     # Allowed values: none, errors, all
     bridge_status_notices: errors
+    # How long should TRANSIENT_DISCONNECT and CONNECTING states be held back before being
+    # reported? Most disconnects recover within a couple of seconds, and debouncing means a
+    # login that drops and reconnects within the delay reports no state changes at all.
+    # Whatever state the login is in when the delay passes is reported as normal, and errors
+    # are never delayed. 0s disables the debounce.
+    transient_state_debounce: 0s
     # How long after an unknown error should the bridge attempt a full reconnect?
     # Must be at least 1 minute. The bridge will add an extra ±20% jitter to this value.
     unknown_error_auto_reconnect: null


### PR DESCRIPTION
At our scale these little flaps tend to generate pretty insane numbers of useless state records.