### PR TITLE
bridgev2/config: add relay user distinguishers

### DIFF
--- a/bridgev2/bridgeconfig/relay.go
+++ b/bridgev2/bridgeconfig/relay.go
@@ -8,6 +8,7 @@ package bridgeconfig
 
 import (
 	"fmt"
+	"hash/crc32"
 	"strings"
 	"text/template"
 
@@ -16,18 +17,20 @@ import (
 	"maunium.net/go/mautrix/bridgev2/networkid"
 	"maunium.net/go/mautrix/event"
 	"maunium.net/go/mautrix/format"
+	"maunium.net/go/mautrix/id"
 )
 
 type RelayConfig struct {
-	Enabled           bool                         `yaml:"enabled"`
-	AdminOnly         bool                         `yaml:"admin_only"`
-	PreferDefault     bool                         `yaml:"prefer_default"`
-	AllowBridge       bool                         `yaml:"allow_bridge"`
-	DefaultRelays     []networkid.UserLoginID      `yaml:"default_relays"`
-	MessageFormats    map[event.MessageType]string `yaml:"message_formats"`
-	DisplaynameFormat string                       `yaml:"displayname_format"`
-	messageTemplates  *template.Template           `yaml:"-"`
-	nameTemplate      *template.Template           `yaml:"-"`
+	Enabled            bool                         `yaml:"enabled"`
+	AdminOnly          bool                         `yaml:"admin_only"`
+	PreferDefault      bool                         `yaml:"prefer_default"`
+	AllowBridge        bool                         `yaml:"allow_bridge"`
+	DefaultRelays      []networkid.UserLoginID      `yaml:"default_relays"`
+	UserDistinguishers []string                     `yaml:"user_distinguishers"`
+	MessageFormats     map[event.MessageType]string `yaml:"message_formats"`
+	DisplaynameFormat  string                       `yaml:"displayname_format"`
+	messageTemplates   *template.Template           `yaml:"-"`
+	nameTemplate       *template.Template           `yaml:"-"`
 }
 
 type umRelayConfig RelayConfig
@@ -52,6 +55,15 @@ func (rc *RelayConfig) UnmarshalYAML(node *yaml.Node) error {
 	}
 
 	return nil
+}
+
+func (rc *RelayConfig) GetUserDistinguisher(userID id.UserID) string {
+	if len(rc.UserDistinguishers) == 0 {
+		return ""
+	}
+
+	hash := crc32.ChecksumIEEE([]byte(userID))
+	return rc.UserDistinguishers[hash%uint32(len(rc.UserDistinguishers))]
 }
 
 type formatData struct {

--- a/bridgev2/bridgeconfig/upgrade.go
+++ b/bridgev2/bridgeconfig/upgrade.go
@@ -59,6 +59,7 @@ func doUpgrade(helper up.Helper) {
 	helper.Copy(up.Bool, "bridge", "relay", "prefer_default")
 	helper.Copy(up.Bool, "bridge", "relay", "allow_bridge")
 	helper.Copy(up.List, "bridge", "relay", "default_relays")
+	helper.Copy(up.List, "bridge", "relay", "user_distinguishers")
 	helper.Copy(up.Map, "bridge", "relay", "message_formats")
 	helper.Copy(up.Str, "bridge", "relay", "displayname_format")
 	helper.Copy(up.Str, "bridge", "portal_create_filter", "mode")

--- a/bridgev2/matrix/mxmain/example-config.yaml
+++ b/bridgev2/matrix/mxmain/example-config.yaml
@@ -103,10 +103,15 @@ bridge:
         allow_bridge: true
         # List of user login IDs which anyone can set as a relay, as long as the relay user is in the room.
         default_relays: []
+        # An array of possible values for the .Sender.Distinguisher variable in message formats.
+        # Each user gets one of the values here, based on a hash of their Matrix user ID.
+        # If the array is empty, .Sender.Distinguisher will also be empty.
+        user_distinguishers: ["🟦", "🟣", "🟩", "⭕️", "🔶", "⬛️", "🔵", "🟢"]
         # The formats to use when sending messages via the relaybot.
         # Available variables:
         #   .Sender.UserID - The Matrix user ID of the sender.
         #   .Sender.Displayname - The display name of the sender (if set).
+        #   .Sender.Distinguisher - The stable distinguisher selected from user_distinguishers.
         #   .Sender.RequiresDisambiguation - Whether the sender's name may be confused with the name of another user in the room.
         #   .Sender.DisambiguatedName - The disambiguated name of the sender. This will be the displayname if set,
         #                               plus the user ID in parentheses if the displayname is not unique.

--- a/bridgev2/networkinterface.go
+++ b/bridgev2/networkinterface.go
@@ -1391,6 +1391,7 @@ type OrigSender struct {
 	User   *User
 	UserID id.UserID
 
+	Distinguisher          string
 	RequiresDisambiguation bool
 	DisambiguatedName      string
 	FormattedName          string

--- a/bridgev2/portal.go
+++ b/bridgev2/portal.go
@@ -799,8 +799,9 @@ func (portal *Portal) handleMatrixEvent(ctx context.Context, sender *User, evt *
 		}
 		login = portal.Relay
 		origSender = &OrigSender{
-			User:   sender,
-			UserID: sender.MXID,
+			User:          sender,
+			UserID:        sender.MXID,
+			Distinguisher: portal.Bridge.Config.Relay.GetUserDistinguisher(sender.MXID),
 		}
 		log.UpdateContext(func(c zerolog.Context) zerolog.Context {
 			return c.Bool("is_relay", true)


### PR DESCRIPTION
This implements the user_distinguishers feature that was previously available in the Python version of the Telegram bridge.

### Checklist

* [x] I have read and followed the contributing guidelines at <https://docs.mau.fi/bridges/general/contributing.html>
