### PR TITLE
bridgev2: add optional interface for suppressing outgoing timeouts

### DIFF
--- a/bridgev2/networkinterface.go
+++ b/bridgev2/networkinterface.go
@@ -355,6 +355,15 @@ type OutgoingTimeoutConfig struct {
 	NoAckMessage  string
 }
 
+// OutgoingTimeoutSuppressingNetworkAPI is an optional interface that network connectors can implement to
+// pause the timeouts in [OutgoingTimeoutConfig] while the remote network is known to be deferring updates.
+type OutgoingTimeoutSuppressingNetworkAPI interface {
+	NetworkAPI
+	// SuppressOutgoingTimeouts is called before checking pending outgoing messages in a portal.
+	// If it returns true, no messages are timed out until the next check.
+	SuppressOutgoingTimeouts() bool
+}
+
 type NetworkGeneralCapabilities struct {
 	// Does the network connector support disappearing messages?
 	// This flag enables the message disappearing loop in the bridge.

--- a/bridgev2/portal.go
+++ b/bridgev2/portal.go
@@ -1476,6 +1476,11 @@ func (portal *Portal) pendingMessageTimeoutLoop(ctx context.Context, cfg *Outgoi
 }
 
 func (portal *Portal) checkPendingMessages(ctx context.Context, cfg *OutgoingTimeoutConfig) {
+	if login := portal.Bridge.GetCachedUserLoginByID(portal.Receiver); login != nil {
+		if suppressor, ok := login.Client.(OutgoingTimeoutSuppressingNetworkAPI); ok && suppressor.SuppressOutgoingTimeouts() {
+			return
+		}
+	}
 	portal.outgoingMessagesLock.Lock()
 	defer portal.outgoingMessagesLock.Unlock()
 	for _, msg := range portal.outgoingMessages {


### PR DESCRIPTION
Some networks (google messages) tell the bridge when they have temporarily stopped pushing updates. 

Add OutgoingTimeoutSuppressingNetworkAPI and skip the pending message checks entirely while the portal's login reports suppression.
