### PR TITLE
bridgev2: keep async DM updates alive after room creation

### DIFF
--- a/bridgev2/ghost.go
+++ b/bridgev2/ghost.go
@@ -326,7 +326,7 @@ func (ghost *Ghost) updateDMPortals(ctx context.Context) {
 		return
 	}
 	for _, portal := range dmPortals {
-		go portal.lockedUpdateInfoFromGhost(ctx, ghost)
+		go portal.lockedUpdateInfoFromGhost(portal.backgroundContext(ctx), ghost)
 	}
 }
 

--- a/bridgev2/portal.go
+++ b/bridgev2/portal.go
@@ -109,6 +109,11 @@ type Portal struct {
 	nextBackfillDoneCallback func(error)
 }
 
+// backgroundContext preserves request logging while using the portal lifecycle.
+func (portal *Portal) backgroundContext(ctx context.Context) context.Context {
+	return zerolog.Ctx(ctx).WithContext(portal.backgroundCtx)
+}
+
 var PortalEventBuffer = 64
 var PanicOnStuckEvent = false
 var EventHandlingTimeoutTicks = 10

--- a/bridgev2/portal_test.go
+++ b/bridgev2/portal_test.go
@@ -1,0 +1,22 @@
+package bridgev2
+
+import (
+	"context"
+	"testing"
+)
+
+func TestPortalBackgroundContextUsesPortalLifetime(t *testing.T) {
+	operationCtx, cancelOperation := context.WithCancel(context.Background())
+	portalCtx, cancelPortal := context.WithCancel(context.Background())
+	portal := &Portal{backgroundCtx: portalCtx}
+	ctx := portal.backgroundContext(operationCtx)
+
+	cancelOperation()
+	if ctx.Err() != nil {
+		t.Fatalf("operation cancellation reached portal context: %v", ctx.Err())
+	}
+	cancelPortal()
+	if ctx.Err() != context.Canceled {
+		t.Fatalf("portal cancellation did not reach portal context: %v", ctx.Err())
+	}
+}


### PR DESCRIPTION
DM portal profile updates can be scheduled while room creation still holds the portal creation lock. The update goroutine waits for that lock while retaining the room-creation context, which is canceled when creation returns. After acquiring the lock, the name or avatar state request therefore fails immediately with context canceled and leaves the room metadata stale.

Run asynchronous DM portal updates with the portal lifecycle context while preserving the originating logger. This allows updates to finish after the creation lock is released while still canceling them when the portal is deleted or the bridge shuts down. Add a regression test for both context lifetime guarantees.

### Checklist

* [x] I have read and followed the contributing guidelines at <https://docs.mau.fi/bridges/general/contributing.html>
