### PR TITLE
bridgev2/errors: add `RespError.WithInternalError` method

### DIFF
--- a/bridgev2/errors.go
+++ b/bridgev2/errors.go
@@ -120,6 +120,10 @@ func (re RespError) Write(w http.ResponseWriter) {
 	mautrix.RespError(re).Write(w)
 }
 
+func (re RespError) WithInternalError(err error) RespError {
+	return RespError(mautrix.RespError(re).WithInternalError(err))
+}
+
 func (re RespError) WithMessage(msg string, args ...any) RespError {
 	return RespError(mautrix.RespError(re).WithMessage(msg, args...))
 }


### PR DESCRIPTION
Needed for https://github.com/mautrix/linkedin/pull/60 + https://github.com/mautrix/twitter/pull/115.