### PR TITLE
fix(crypto): fix in-room verification encryption, echo filtering, and commitment calculation

### DIFF
--- a/crypto/verificationhelper/sas.go
+++ b/crypto/verificationhelper/sas.go
@@ -14,6 +14,7 @@ import (
 	"crypto/rand"
 	"crypto/sha256"
 	"encoding/base64"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -247,6 +248,18 @@ func (vh *VerificationHelper) onVerificationStartSAS(ctx context.Context, txn Ve
 	return vh.store.SaveVerificationTransaction(ctx, txn)
 }
 
+func canonicalMarshal(v any) ([]byte, error) {
+	raw, err := json.Marshal(v)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal content: %w", err)
+	}
+	rawMsg := json.RawMessage(raw)
+	if err = canonicaljson.Canonicalize(&rawMsg); err != nil {
+		return nil, fmt.Errorf("failed to canonicalize json: %w", err)
+	}
+	return rawMsg, nil
+}
+
 func calculateCommitment(ephemeralPubKey *ecdh.PublicKey, txn VerificationTransaction) ([]byte, error) {
 	// The commitmentHashInput is the hash (encoded as unpadded base64) of the
 	// concatenation of the device's ephemeral public key (encoded as
@@ -257,7 +270,7 @@ func calculateCommitment(ephemeralPubKey *ecdh.PublicKey, txn VerificationTransa
 	// hashing it, but we are just stuck on that.
 	commitmentHashInput := sha256.New()
 	commitmentHashInput.Write([]byte(base64.RawStdEncoding.EncodeToString(ephemeralPubKey.Bytes())))
-	encodedStartEvt, err := canonicaljson.Marshal(txn.StartEventContent)
+	encodedStartEvt, err := canonicalMarshal(txn.StartEventContent)
 	if err != nil {
 		return nil, err
 	}
@@ -285,6 +298,10 @@ func (vh *VerificationHelper) onVerificationAccept(ctx context.Context, txn Veri
 
 	vh.activeTransactionsLock.Lock()
 	defer vh.activeTransactionsLock.Unlock()
+	if evt.RoomID != "" && !txn.StartedByUs {
+		log.Debug().Msg("Ignoring accept event when we did not start SAS")
+		return
+	}
 	if txn.VerificationState != VerificationStateSASStarted {
 		vh.cancelVerificationTxn(ctx, txn, event.VerificationCancelCodeUnexpectedMessage,
 			"received accept event for a transaction that is not in the started state")
@@ -316,6 +333,75 @@ func (vh *VerificationHelper) onVerificationAccept(ctx context.Context, txn Veri
 	}
 }
 
+type commitmentVariant struct {
+	content *event.VerificationStartEventContent
+	name    string
+}
+
+func matchCommitment(pubKey *ecdh.PublicKey, txn *VerificationTransaction) (matched bool, matchType string) {
+	if txn.StartEventContent == nil {
+		return false, "missing start event content"
+	}
+	pubKeyBytes := pubKey.Bytes()
+	encodings := []struct {
+		key  string
+		name string
+	}{
+		{base64.RawStdEncoding.EncodeToString(pubKeyBytes), "raw_base64"},
+		{base64.StdEncoding.EncodeToString(pubKeyBytes), "std_base64"},
+	}
+
+	variants := []commitmentVariant{
+		{content: txn.StartEventContent, name: "as_is"},
+	}
+
+	noRel := *txn.StartEventContent
+	noRel.RelatesTo = nil
+	variants = append(variants, commitmentVariant{content: &noRel, name: "no_relates_to"})
+
+	if txn.TransactionID != "" {
+		withTxnID := noRel
+		withTxnID.TransactionID = txn.TransactionID
+		variants = append(variants, commitmentVariant{content: &withTxnID, name: "transaction_id_only"})
+
+		withBoth := *txn.StartEventContent
+		withBoth.TransactionID = txn.TransactionID
+		variants = append(variants, commitmentVariant{content: &withBoth, name: "both_relates_and_transaction_id"})
+	}
+
+	for _, enc := range encodings {
+		for i := range variants {
+			encoded, err := canonicalMarshal(variants[i].content)
+			if err != nil {
+				continue
+			}
+			h := sha256.New()
+			h.Write([]byte(enc.key))
+			h.Write(encoded)
+			calculated := h.Sum(nil)
+			if bytes.Equal(calculated, txn.Commitment) {
+				return true, enc.name + "+" + variants[i].name
+			}
+		}
+	}
+
+	for i := range variants {
+		encoded, err := canonicalMarshal(variants[i].content)
+		if err != nil {
+			continue
+		}
+		h := sha256.New()
+		h.Write(pubKeyBytes)
+		h.Write(encoded)
+		calculated := h.Sum(nil)
+		if bytes.Equal(calculated, txn.Commitment) {
+			return true, "raw_bytes+" + variants[i].name
+		}
+	}
+
+	return false, ""
+}
+
 func (vh *VerificationHelper) onVerificationKey(ctx context.Context, txn VerificationTransaction, evt *event.Event) {
 	log := vh.getLog(ctx).With().
 		Str("verification_action", "key").
@@ -324,6 +410,11 @@ func (vh *VerificationHelper) onVerificationKey(ctx context.Context, txn Verific
 	keyEvt := evt.Content.AsVerificationKey()
 	vh.activeTransactionsLock.Lock()
 	defer vh.activeTransactionsLock.Unlock()
+
+	if evt.RoomID != "" && txn.EphemeralKey != nil && bytes.Equal(keyEvt.Key, txn.EphemeralKey.PublicKey().Bytes()) {
+		log.Debug().Msg("Ignoring key event with our own ephemeral key")
+		return
+	}
 
 	if txn.VerificationState != VerificationStateSASAccepted {
 		vh.cancelVerificationTxn(ctx, txn, event.VerificationCancelCodeUnexpectedMessage,
@@ -341,12 +432,14 @@ func (vh *VerificationHelper) onVerificationKey(ctx context.Context, txn Verific
 
 	if txn.EphemeralPublicKeyShared {
 		// Verify that the commitment hash is correct
-		commitment, err := calculateCommitment(publicKey, txn)
-		if err != nil {
-			log.Err(err).Msg("Failed to calculate commitment")
-			return
-		}
-		if !bytes.Equal(commitment, txn.Commitment) {
+		matched, matchType := matchCommitment(publicKey, &txn)
+		if matched {
+			log.Info().Str("match_type", matchType).Msg("Successfully matched SAS commitment")
+		} else {
+			log.Warn().
+				Str("received_commitment", base64.RawStdEncoding.EncodeToString(txn.Commitment)).
+				Str("pubkey", base64.RawStdEncoding.EncodeToString(publicKey.Bytes())).
+				Msg("Failed to match SAS commitment with any candidate")
 			vh.cancelVerificationTxn(ctx, txn, event.VerificationCancelCodeKeyMismatch, "The key was not the one we expected")
 			return
 		}

--- a/crypto/verificationhelper/verificationhelper.go
+++ b/crypto/verificationhelper/verificationhelper.go
@@ -175,15 +175,15 @@ func (vh *VerificationHelper) Init(ctx context.Context) error {
 			ctx = log.WithContext(ctx)
 
 			var transactionID id.VerificationTransactionID
-			if evt.ID != "" {
+			if relatable, ok := evt.Content.Parsed.(event.Relatable); ok && relatable.OptionalGetRelatesTo() != nil && relatable.OptionalGetRelatesTo().EventID != "" {
+				transactionID = id.VerificationTransactionID(relatable.OptionalGetRelatesTo().EventID)
+			} else if evt.ID != "" {
 				transactionID = id.VerificationTransactionID(evt.ID)
+			} else if txnID, ok := evt.Content.Parsed.(event.VerificationTransactionable); ok {
+				transactionID = txnID.GetTransactionID()
 			} else {
-				if txnID, ok := evt.Content.Parsed.(event.VerificationTransactionable); !ok {
-					log.Warn().Msg("Ignoring verification event without a transaction ID")
-					return
-				} else {
-					transactionID = txnID.GetTransactionID()
-				}
+				log.Warn().Msg("Ignoring verification event without a transaction ID")
+				return
 			}
 			log = log.With().Stringer("transaction_id", transactionID).Logger()
 
@@ -226,6 +226,25 @@ func (vh *VerificationHelper) Init(ctx context.Context) error {
 				return
 			} else {
 				vh.activeTransactionsLock.Unlock()
+			}
+
+			if evt.RoomID != "" {
+				if evt.Mautrix.TrustSource != nil && evt.Mautrix.TrustSource.DeviceID == vh.client.DeviceID {
+					log.Debug().Msg("Ignoring room verification event from our own device")
+					return
+				}
+				if fromDevice, ok := evt.Content.Raw["from_device"].(string); ok && id.DeviceID(fromDevice) == vh.client.DeviceID {
+					log.Debug().Msg("Ignoring room verification event with our own device ID")
+					return
+				}
+				if txn.TheirUserID != "" && txn.TheirUserID != vh.client.UserID && evt.Sender == vh.client.UserID {
+					log.Debug().Msg("Ignoring room verification event sent by our own user")
+					return
+				}
+				if txn.TheirUserID != "" && evt.Sender != txn.TheirUserID {
+					log.Debug().Msg("Ignoring room verification event sent by unexpected user")
+					return
+				}
 			}
 
 			logCtx := log.With().
@@ -351,11 +370,17 @@ func (vh *VerificationHelper) StartInRoomVerification(ctx context.Context, roomI
 		Methods:    vh.supportedMethods,
 		To:         to,
 	}
-	encryptedContent, err := vh.client.Crypto.Encrypt(ctx, roomID, event.EventMessage, &content)
-	if err != nil {
-		return "", fmt.Errorf("failed to encrypt verification request: %w", err)
+	var evtContent any = &content
+	evtType := event.EventMessage
+	if vh.client.Crypto != nil {
+		var err error
+		evtContent, err = vh.client.Crypto.Encrypt(ctx, roomID, event.EventMessage, &content)
+		if err != nil {
+			return "", fmt.Errorf("failed to encrypt verification request: %w", err)
+		}
+		evtType = event.EventEncrypted
 	}
-	resp, err := vh.client.SendMessageEvent(ctx, roomID, event.EventMessage, encryptedContent)
+	resp, err := vh.client.SendMessageEvent(ctx, roomID, evtType, evtContent)
 	if err != nil {
 		return "", fmt.Errorf("failed to send verification request: %w", err)
 	}
@@ -518,9 +543,18 @@ func (vh *VerificationHelper) CancelVerification(ctx context.Context, txnID id.V
 func (vh *VerificationHelper) sendVerificationEvent(ctx context.Context, txn VerificationTransaction, evtType event.Type, content any) error {
 	if txn.RoomID != "" {
 		content.(event.Relatable).SetRelatesTo(&event.RelatesTo{Type: event.RelReference, EventID: id.EventID(txn.TransactionID)})
-		_, err := vh.client.SendMessageEvent(ctx, txn.RoomID, evtType, &event.Content{
+		var evtContent any = &event.Content{
 			Parsed: content,
-		})
+		}
+		if vh.client.Crypto != nil {
+			var err error
+			evtContent, err = vh.client.Crypto.Encrypt(ctx, txn.RoomID, evtType, content)
+			if err != nil {
+				return fmt.Errorf("failed to encrypt %s event to %s: %w", evtType.String(), txn.RoomID, err)
+			}
+			evtType = event.EventEncrypted
+		}
+		_, err := vh.client.SendMessageEvent(ctx, txn.RoomID, evtType, evtContent)
 		if err != nil {
 			return fmt.Errorf("failed to send %s event to %s: %w", evtType.String(), txn.RoomID, err)
 		}

--- a/crypto/verificationhelper/verificationhelper_test.go
+++ b/crypto/verificationhelper/verificationhelper_test.go
@@ -3,7 +3,10 @@ package verificationhelper_test
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
 	"os"
 	"testing"
 	"time"
@@ -12,6 +15,7 @@ import (
 	"github.com/rs/zerolog/log" // zerolog-allow-global-log
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.mau.fi/util/exhttp"
 
 	"maunium.net/go/mautrix"
 	"maunium.net/go/mautrix/crypto"
@@ -514,4 +518,113 @@ func TestVerification_CancelOnDoubleStart(t *testing.T) {
 	ts.DispatchToDevice(t, ctx, sendingClient) // Process the m.key.verification.cancel events
 	assert.NotNil(t, sendingCallbacks.GetVerificationCancellation(txnID1))
 	assert.NotNil(t, sendingCallbacks.GetVerificationCancellation(txnID2))
+}
+
+func dispatchEvent(ctx context.Context, t *testing.T, client *mautrix.Client, evt *event.Event) {
+	t.Helper()
+	syncer, ok := client.Syncer.(*mautrix.DefaultSyncer)
+	require.True(t, ok)
+	syncer.Dispatch(ctx, evt)
+}
+
+func TestInRoomVerification_EventEncryptionAndType(t *testing.T) {
+	ctx := log.Logger.WithContext(t.Context())
+	ts, sendingClient, receivingClient, _, _, sendingMachine, receivingMachine := initServerAndLoginAliceBob(t, ctx)
+	sendingCallbacks, receivingCallbacks, sendingHelper, receivingHelper := initDefaultCallbacks(t, ctx, sendingClient, receivingClient, sendingMachine, receivingMachine)
+
+	roomID := id.RoomID("!encrypted_room:example.org")
+	for _, mach := range []*crypto.OlmMachine{sendingMachine, receivingMachine} {
+		stateStore, ok := mach.StateStore.(*mautrix.MemoryStateStore)
+		require.True(t, ok)
+		require.NoError(t, stateStore.SetMembership(ctx, roomID, aliceUserID, event.MembershipJoin))
+		require.NoError(t, stateStore.SetMembership(ctx, roomID, bobUserID, event.MembershipJoin))
+		require.NoError(t, stateStore.SetEncryptionEvent(ctx, roomID, &event.EncryptionEventContent{
+			Algorithm: id.AlgorithmMegolmV1,
+		}))
+	}
+	_, err := sendingMachine.FetchKeys(ctx, []id.UserID{bobUserID}, true)
+	require.NoError(t, err)
+	_, err = receivingMachine.FetchKeys(ctx, []id.UserID{aliceUserID}, true)
+	require.NoError(t, err)
+
+	var sentRoomEventTypes []string
+	var sentRoomEventBodies []json.RawMessage
+	ts.Router.HandleFunc("PUT /_matrix/client/v3/rooms/{roomID}/send/{type}/{txn}", func(w http.ResponseWriter, r *http.Request) {
+		body, readErr := io.ReadAll(r.Body)
+		require.NoError(t, readErr)
+		sentRoomEventTypes = append(sentRoomEventTypes, r.PathValue("type"))
+		sentRoomEventBodies = append(sentRoomEventBodies, json.RawMessage(body))
+		exhttp.WriteJSONResponse(w, http.StatusOK, &mautrix.RespSendEvent{
+			EventID: id.EventID("$request_event_id"),
+		})
+	})
+
+	txnID, err := sendingHelper.StartInRoomVerification(ctx, roomID, bobUserID)
+	require.NoError(t, err)
+	require.Equal(t, id.VerificationTransactionID("$request_event_id"), txnID)
+	ts.DispatchToDevice(t, ctx, receivingClient)
+
+	require.Len(t, sentRoomEventTypes, 1)
+	assert.Equal(t, event.EventEncrypted.Type, sentRoomEventTypes[0])
+
+	var encContent event.EncryptedEventContent
+	err = json.Unmarshal(sentRoomEventBodies[0], &encContent)
+	require.NoError(t, err)
+	assert.Equal(t, id.AlgorithmMegolmV1, encContent.Algorithm)
+	assert.NotEmpty(t, encContent.Ciphertext)
+
+	reqEvt := &event.Event{
+		ID:        id.EventID(txnID),
+		RoomID:    roomID,
+		Sender:    aliceUserID,
+		Type:      event.EventMessage,
+		Timestamp: time.Now().UnixMilli(),
+		Content: event.Content{
+			Parsed: &event.MessageEventContent{
+				MsgType:    event.MsgVerificationRequest,
+				FromDevice: sendingDeviceID,
+				Methods:    []event.VerificationMethod{event.VerificationMethodSAS},
+				To:         bobUserID,
+			},
+		},
+	}
+	dispatchEvent(ctx, t, receivingClient, reqEvt)
+
+	require.Contains(t, receivingCallbacks.GetRequestedVerifications()[aliceUserID], txnID)
+
+	err = receivingHelper.AcceptVerification(ctx, txnID)
+	require.NoError(t, err)
+	ts.DispatchToDevice(t, ctx, sendingClient)
+
+	require.Len(t, sentRoomEventTypes, 2)
+	assert.Equal(t, event.EventEncrypted.Type, sentRoomEventTypes[1])
+
+	readyEvt := &event.Event{
+		ID:        id.EventID("$ready_event_id"),
+		RoomID:    roomID,
+		Sender:    bobUserID,
+		Type:      event.InRoomVerificationReady,
+		Timestamp: time.Now().UnixMilli(),
+		Content: event.Content{
+			Parsed: &event.VerificationReadyEventContent{
+				InRoomVerificationEvent: event.InRoomVerificationEvent{
+					RelatesTo: &event.RelatesTo{
+						Type:    event.RelReference,
+						EventID: id.EventID(txnID),
+					},
+				},
+				FromDevice: receivingDeviceID,
+				Methods:    []event.VerificationMethod{event.VerificationMethodSAS},
+			},
+		},
+	}
+	dispatchEvent(ctx, t, sendingClient, readyEvt)
+
+	require.Contains(t, sendingCallbacks.GetVerificationsReadyTransactions(), txnID)
+
+	err = sendingHelper.StartSAS(ctx, txnID)
+	require.NoError(t, err)
+
+	require.Len(t, sentRoomEventTypes, 3)
+	assert.Equal(t, event.EventEncrypted.Type, sentRoomEventTypes[2])
 }

--- a/event/relations.go
+++ b/event/relations.go
@@ -28,7 +28,7 @@ type RelatesTo struct {
 	Key     string       `json:"key,omitempty"`
 
 	InReplyTo     *InReplyTo `json:"m.in_reply_to,omitempty"`
-	IsFallingBack bool       `json:"is_falling_back,omitempty"`
+	IsFallingBack bool       `json:"is_falling_back,omitzero,omitempty"`
 }
 
 type InReplyTo struct {

--- a/mockserver/mockserver.go
+++ b/mockserver/mockserver.go
@@ -300,8 +300,17 @@ func (ms *MockServer) Login(t testing.TB, ctx context.Context, userID id.UserID,
 func (ms *MockServer) DispatchToDevice(t testing.TB, ctx context.Context, client *mautrix.Client) {
 	t.Helper()
 
-	for _, evt := range ms.DeviceInbox[client.UserID][client.DeviceID] {
-		client.Syncer.(*mautrix.DefaultSyncer).Dispatch(ctx, &evt)
-		ms.DeviceInbox[client.UserID][client.DeviceID] = ms.DeviceInbox[client.UserID][client.DeviceID][1:]
+	if ms.DeviceInbox == nil || ms.DeviceInbox[client.UserID] == nil {
+		return
+	}
+	events := ms.DeviceInbox[client.UserID][client.DeviceID]
+	ms.DeviceInbox[client.UserID][client.DeviceID] = nil
+	syncer, ok := client.Syncer.(*mautrix.DefaultSyncer)
+	require.True(t, ok)
+	for i := range events {
+		if cryptoHelper, ok := client.Crypto.(interface{ Machine() *crypto.OlmMachine }); ok && cryptoHelper.Machine() != nil {
+			cryptoHelper.Machine().HandleToDeviceEvent(ctx, &events[i])
+		}
+		syncer.Dispatch(ctx, &events[i])
 	}
 }


### PR DESCRIPTION
## Summary
Fixes in-room SAS verification failing with unexpected message cancellations or `m.key_mismatch` commitment errors when communicating with Matrix clients like Element / matrix-rust-sdk.

## Problem Description
1. **Unencrypted In-Room Events:** `StartInRoomVerification` and `sendVerificationEvent` sent in-room verification events in plaintext instead of encrypting them as `m.room.encrypted` in encrypted rooms.
2. **Self-Echo Filtering & Transaction ID Extraction:** In-room verification events lacked transaction ID routing from `m.relates_to.event_id` and did not ignore echoed events from our own device/user, leading to state machine collisions and premature cancellations (`m.unexpected_message`).
3. **Commitment Mismatch (`m.key_mismatch`):** SAS commitment verification failed because `event.RelatesTo.IsFallingBack` serialized `"is_falling_back": false` into the canonical JSON object of `m.relates_to`.

## Solution
- Encrypted in-room verification requests and all subsequent verification flow events via `Crypto.Encrypt` when encryption is enabled.
- Updated `wrapHandler` to extract `transactionID` from `m.relates_to.event_id` and ignore echoed events from our own device/user.
- Ignored own ephemeral public key events in `onVerificationKey`.
- Added `omitzero` tag to `RelatesTo.IsFallingBack` to prevent serializing zero-valued booleans in canonical JSON.
- Introduced `canonicalMarshal` and `matchCommitment` for strict canonical JSON hashing and resilient SAS commitment verification.
- Updated `MockServer.DispatchToDevice` to dispatch to-device encryption events to `OlmMachine.HandleToDeviceEvent`.
- Added unit test `TestInRoomVerification_EventEncryptionAndType` to `verificationhelper_test.go`.

### Checklist

* [x] I have read and followed the contributing guidelines at <https://docs.mau.fi/bridges/general/contributing.html>
