### PR TITLE
bridgev2: add optional wait for connected when sending

### DIFF
--- a/bridgev2/bridgeconfig/config.go
+++ b/bridgev2/bridgeconfig/config.go
@@ -74,6 +74,7 @@ type BridgeConfig struct {
 	NoBridgeInfoStateKey          bool               `yaml:"no_bridge_info_state_key"`
 	BridgeStatusNotices           string             `yaml:"bridge_status_notices"`
 	TransientStateDebounce        time.Duration      `yaml:"transient_state_debounce"`
+	SendReconnectWait             time.Duration      `yaml:"send_reconnect_wait"`
 	UnknownErrorAutoReconnect     time.Duration      `yaml:"unknown_error_auto_reconnect"`
 	UnknownErrorMaxAutoReconnects int                `yaml:"unknown_error_max_auto_reconnects"`
 	BridgeMatrixLeave             bool               `yaml:"bridge_matrix_leave"`

--- a/bridgev2/bridgeconfig/upgrade.go
+++ b/bridgev2/bridgeconfig/upgrade.go
@@ -33,6 +33,7 @@ func doUpgrade(helper up.Helper) {
 	helper.Copy(up.Bool, "bridge", "no_bridge_info_state_key")
 	helper.Copy(up.Str|up.Null, "bridge", "bridge_status_notices")
 	helper.Copy(up.Str|up.Int|up.Null, "bridge", "transient_state_debounce")
+	helper.Copy(up.Str|up.Int|up.Null, "bridge", "send_reconnect_wait")
 	helper.Copy(up.Str|up.Int|up.Null, "bridge", "unknown_error_auto_reconnect")
 	helper.Copy(up.Int, "bridge", "unknown_error_max_auto_reconnects")
 	helper.Copy(up.Bool, "bridge", "bridge_matrix_leave")

--- a/bridgev2/matrix/mxmain/example-config.yaml
+++ b/bridgev2/matrix/mxmain/example-config.yaml
@@ -29,6 +29,9 @@ bridge:
     # How long should TRANSIENT_DISCONNECT and CONNECTING states be held back before being reported?
     # If another state update occurs while waiting, the previous state won't be reported at all.
     transient_state_debounce: 0s
+    # When an outgoing message can't be sent because the login is not connected (e.g. mid-reconnect),
+    # wait this long for it to reconnect before failing the message.
+    send_reconnect_wait: 0s
     # How long after an unknown error should the bridge attempt a full reconnect?
     # Must be at least 1 minute. The bridge will add an extra ±20% jitter to this value.
     unknown_error_auto_reconnect: null

--- a/bridgev2/portal.go
+++ b/bridgev2/portal.go
@@ -709,6 +709,31 @@ func (portal *Portal) FindPreferredLogin(ctx context.Context, user *User, allowR
 	}
 }
 
+func (portal *Portal) waitForReceiverLogin(ctx context.Context, login *UserLogin) bool {
+	wait := portal.Bridge.Config.SendReconnectWait
+	if wait <= 0 || login == nil || login.Client == nil {
+		return false
+	}
+	switch login.BridgeState.GetPrev().StateEvent {
+	case status.StateBadCredentials, status.StateLoggedOut, status.StateUnconfigured:
+		return false
+	}
+	ctx, cancel := context.WithTimeout(ctx, wait)
+	defer cancel()
+	ticker := time.NewTicker(100 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		if login.Client.IsLoggedIn() {
+			return true
+		}
+		select {
+		case <-ctx.Done():
+			return false
+		case <-ticker.C:
+		}
+	}
+}
+
 func (portal *Portal) sendSuccessStatus(ctx context.Context, evt *event.Event, streamOrder int64, newEventID id.EventID) {
 	info := StatusEventInfoFromEvent(evt)
 	info.StreamOrder = streamOrder
@@ -770,6 +795,10 @@ func (portal *Portal) handleMatrixEvent(ctx context.Context, sender *User, evt *
 		return portal.handleMatrixTombstone(ctx, evt)
 	}
 	login, userPortal, err := portal.FindPreferredLogin(ctx, sender, true)
+	if errors.Is(err, ErrNotLoggedIn) && portal.waitForReceiverLogin(ctx, login) {
+		log.Debug().Msg("Receiver login reconnected while waiting, retrying event")
+		login, userPortal, err = portal.FindPreferredLogin(ctx, sender, true)
+	}
 	if err != nil {
 		log.Err(err).Msg("Failed to get user login to handle Matrix event")
 		if errors.Is(err, ErrNotLoggedIn) {


### PR DESCRIPTION
This allows users to configure a max time the bridge will block waiting for the user to be connected before failing the message. This is useful where random disconnects/reconnects that take a few seconds are causing large numbers of unnecessary send failures.
