### PR TITLE
bridgev2: reconcile ghost profile drift during participant sync

### DIFF
--- a/bridgev2/ghost.go
+++ b/bridgev2/ghost.go
@@ -404,3 +404,30 @@ func (ghost *Ghost) pushProfileChanges(ctx context.Context, nameChanged, avatarC
 		}
 	}
 }
+
+// Check that the ghosts profile information matches the current content of an event. This allows
+// member events and ghosts to self heal in case they ever drift due to bugs.
+func (ghost *Ghost) reconcileProfile(ctx context.Context, current *event.MemberEventContent) {
+	nameDrift := ghost.NameSet && ghost.Name != "" && current.Displayname != ghost.Name
+	avatarDrift := ghost.AvatarSet && ghost.AvatarMXC != "" && current.AvatarURL != ghost.AvatarMXC
+	if !nameDrift && !avatarDrift {
+		return
+	}
+	zerolog.Ctx(ctx).Warn().
+		Str("ghost_id", string(ghost.ID)).
+		Bool("name_drift", nameDrift).
+		Bool("avatar_drift", avatarDrift).
+		Str("expected_name", ghost.Name).
+		Str("actual_name", current.Displayname).
+		Msg("Ghost profile drifted from the server copy, re-pushing")
+	if nameDrift {
+		ghost.NameSet = false
+	}
+	if avatarDrift {
+		ghost.AvatarSet = false
+	}
+	ghost.pushProfileChanges(ctx, nameDrift, avatarDrift, false)
+	if err := ghost.Bridge.DB.Ghost.Update(ctx, ghost.Ghost); err != nil {
+		zerolog.Ctx(ctx).Err(err).Msg("Failed to save ghost after profile reconcile")
+	}
+}

--- a/bridgev2/ghost.go
+++ b/bridgev2/ghost.go
@@ -405,11 +405,15 @@ func (ghost *Ghost) pushProfileChanges(ctx context.Context, nameChanged, avatarC
 	}
 }
 
-// Check that the ghosts profile information matches the current content of an event. This allows
-// member events and ghosts to self heal in case they ever drift due to bugs.
-func (ghost *Ghost) reconcileProfile(ctx context.Context, current *event.MemberEventContent) {
-	nameDrift := ghost.NameSet && ghost.Name != "" && current.Displayname != ghost.Name
-	avatarDrift := ghost.AvatarSet && ghost.AvatarMXC != "" && current.AvatarURL != ghost.AvatarMXC
+func (ghost *Ghost) reconcileProfile(ctx context.Context, current *event.MemberEventContent, updatedProfile *UserInfo) {
+	// Re-set the profile on the server if:
+	// * the bridge database thinks the profile field is set
+	// * the member event has a different value than the bridge database
+	// * the value isn't being updated right after this call
+	nameDrift := ghost.NameSet && ghost.Name != "" && current.Displayname != ghost.Name &&
+		(updatedProfile == nil || updatedProfile.Name == nil || *updatedProfile.Name == ghost.Name)
+	avatarDrift := ghost.AvatarSet && ghost.AvatarMXC != "" && current.AvatarURL != ghost.AvatarMXC &&
+		(updatedProfile == nil || updatedProfile.Avatar == nil || updatedProfile.Avatar.ID == ghost.AvatarID)
 	if !nameDrift && !avatarDrift {
 		return
 	}

--- a/bridgev2/portal.go
+++ b/bridgev2/portal.go
@@ -4828,6 +4828,9 @@ func (portal *Portal) syncParticipants(
 				zerolog.Ctx(ctx).Err(err).Str("ghost_id", string(member.Sender)).Msg("Failed to get ghost from member list to update info")
 			} else {
 				ghost.UpdateInfo(ctx, member.UserInfo)
+				if current, ok := currentMembers[ghost.Intent.GetMXID()]; ok && current.Membership == event.MembershipJoin {
+					ghost.reconcileProfile(ctx, current)
+				}
 			}
 		}
 		intent, extraUserID, err := portal.getIntentAndUserMXIDFor(ctx, member.EventSender, source, loginsInPortal, 0)

--- a/bridgev2/portal.go
+++ b/bridgev2/portal.go
@@ -4827,10 +4827,10 @@ func (portal *Portal) syncParticipants(
 			if err != nil {
 				zerolog.Ctx(ctx).Err(err).Str("ghost_id", string(member.Sender)).Msg("Failed to get ghost from member list to update info")
 			} else {
-				ghost.UpdateInfo(ctx, member.UserInfo)
 				if current, ok := currentMembers[ghost.Intent.GetMXID()]; ok && current.Membership == event.MembershipJoin && ptr.Val(member.Nickname) == "" {
-					ghost.reconcileProfile(ctx, current)
+					ghost.reconcileProfile(ctx, current, member.UserInfo)
 				}
+				ghost.UpdateInfo(ctx, member.UserInfo)
 			}
 		}
 		intent, extraUserID, err := portal.getIntentAndUserMXIDFor(ctx, member.EventSender, source, loginsInPortal, 0)

--- a/bridgev2/portal.go
+++ b/bridgev2/portal.go
@@ -4828,7 +4828,7 @@ func (portal *Portal) syncParticipants(
 				zerolog.Ctx(ctx).Err(err).Str("ghost_id", string(member.Sender)).Msg("Failed to get ghost from member list to update info")
 			} else {
 				ghost.UpdateInfo(ctx, member.UserInfo)
-				if current, ok := currentMembers[ghost.Intent.GetMXID()]; ok && current.Membership == event.MembershipJoin {
+				if current, ok := currentMembers[ghost.Intent.GetMXID()]; ok && current.Membership == event.MembershipJoin && ptr.Val(member.Nickname) == "" {
 					ghost.reconcileProfile(ctx, current)
 				}
 			}


### PR DESCRIPTION
A ghost whose display name or avatar is lost on the server stays stale forever, because the bridge trusts NameSet/AvatarSet and never re-writes an unchanged profile.

During participant sync, compare the bridge's expected name and avatar against the server's current member content and re-push when they drift.

This has happened on our custom homeserver as a result of bugs, now fixed, this just allows bridges to self heal. It's also basically free as well since all the data is in place already.