### PR TITLE
appservice/intent: allow setting avatar when profile field is missing

### DIFF
--- a/appservice/intent.go
+++ b/appservice/intent.go
@@ -502,9 +502,9 @@ func (intent *IntentAPI) SetAvatarURL(ctx context.Context, avatarURL id.ContentU
 		return err
 	}
 	resp, err := intent.Client.GetOwnAvatarURL(ctx)
-	if err != nil {
+	if err != nil && !errors.Is(err, mautrix.MNotFound) {
 		return fmt.Errorf("failed to check current avatar URL: %w", err)
-	} else if resp.FileID == avatarURL.FileID && resp.Homeserver == avatarURL.Homeserver {
+	} else if err == nil && resp.FileID == avatarURL.FileID && resp.Homeserver == avatarURL.Homeserver {
 		// No need to update
 		return nil
 	}


### PR DESCRIPTION
Homeservers may return M_NOT_FOUND when avatar_url has not been set for a profile yet, for example Tuwunel. SetAvatarURL previously treated this valid response as a fatal error and returned before sending the new avatar.

Treat M_NOT_FOUND as an empty avatar and continue with the PUT request. All other errors remain fatal.

### Checklist

* [x] I have read and followed the contributing guidelines at <https://docs.mau.fi/bridges/general/contributing.html>
