### PR TITLE
[DESK-23336] bridgev2: add min/max length hints to login input fields

### DIFF
--- a/bridgev2/login.go
+++ b/bridgev2/login.go
@@ -315,8 +315,8 @@ type LoginInputDataField struct {
 	// A regex pattern that the client can use to validate input client-side.
 	Pattern string `json:"pattern,omitempty"`
 	// Minimum and maximum input length as a hint for the client
-	MinLength int `json:"min_length,omitempty"`
-	MaxLength int `json:"max_length,omitempty"`
+	MinLength int `json:"min_length,omitzero"`
+	MaxLength int `json:"max_length,omitzero"`
 	// For fields of type select, the valid options.
 	// Pattern may also be filled with a regex that matches the same options.
 	Options []string `json:"options,omitempty"`

--- a/bridgev2/login.go
+++ b/bridgev2/login.go
@@ -314,6 +314,9 @@ type LoginInputDataField struct {
 	DefaultValue string `json:"default_value,omitempty"`
 	// A regex pattern that the client can use to validate input client-side.
 	Pattern string `json:"pattern,omitempty"`
+	// Minimum and maximum input length as a hint for the client
+	MinLength int `json:"min_length,omitempty"`
+	MaxLength int `json:"max_length,omitempty"`
 	// For fields of type select, the valid options.
 	// Pattern may also be filled with a regex that matches the same options.
 	Options []string `json:"options,omitempty"`

--- a/bridgev2/matrix/provisioning.yaml
+++ b/bridgev2/matrix/provisioning.yaml
@@ -883,6 +883,12 @@ components:
                       type: string
                       format: regex
                       description: A regular expression that the field value must match.
+                    min_length:
+                      type: integer
+                      description: Minimum input length as a hint for the client.
+                    max_length:
+                      type: integer
+                      description: Maximum input length as a hint for the client.
                     options:
                       type: array
                       description: For fields of type select, the valid options.


### PR DESCRIPTION
Clients only receive a regex pattern for user input fields, to know how many characters to accept they would have to parse the regex. Bridges that ask for fixed-length codes can now say so directly, letting clients cap the input and render a proper code field.

### Checklist

* [x] I have read and followed the contributing guidelines at <https://docs.mau.fi/bridges/general/contributing.html>
