### PR TITLE
crypto: update signing_key on device upsert

### DIFF
--- a/crypto/signing_key_repro_test.go
+++ b/crypto/signing_key_repro_test.go
@@ -1,0 +1,41 @@
+package crypto
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"maunium.net/go/mautrix/id"
+)
+
+// A client that logs out and logs back in under the same device ID gets a fresh
+// Olm account. PutDevices must store the new signing key, not keep the old one.
+func TestPutDevicesUpdatesSigningKeyAfterAccountReset(t *testing.T) {
+	store := getCryptoStores(t)["sql"].(*SQLCryptoStore)
+	ctx := context.Background()
+
+	const userID = id.UserID("@user:example.org")
+	const deviceID = id.DeviceID("DEVICE")
+
+	put := func(identity id.IdentityKey, signing id.SigningKey) {
+		t.Helper()
+		require.NoError(t, store.PutDevices(ctx, userID, map[id.DeviceID]*id.Device{
+			deviceID: {UserID: userID, DeviceID: deviceID, IdentityKey: identity, SigningKey: signing},
+		}))
+	}
+
+	put("identity-1", "signing-1")
+
+	// Logging out only flips deleted=true; the row stays.
+	require.NoError(t, store.PutDevices(ctx, userID, map[id.DeviceID]*id.Device{}))
+
+	put("identity-2", "signing-2")
+
+	device, err := store.FindDeviceByKey(ctx, userID, "identity-2")
+	require.NoError(t, err)
+	require.NotNil(t, device)
+	assert.Equal(t, id.IdentityKey("identity-2"), device.IdentityKey)
+	assert.Equal(t, id.SigningKey("signing-2"), device.SigningKey)
+}

--- a/crypto/sql_store.go
+++ b/crypto/sql_store.go
@@ -802,7 +802,7 @@ const deviceInsertQuery = `
 INSERT INTO crypto_device (user_id, device_id, identity_key, signing_key, trust, deleted, name)
 VALUES ($1, $2, $3, $4, $5, $6, $7)
 ON CONFLICT (user_id, device_id) DO UPDATE
-    SET identity_key=excluded.identity_key, deleted=excluded.deleted, trust=excluded.trust, name=excluded.name
+    SET identity_key=excluded.identity_key, signing_key=excluded.signing_key, deleted=excluded.deleted, trust=excluded.trust, name=excluded.name
 `
 
 var deviceMassInsertTemplate = strings.ReplaceAll(deviceInsertQuery, "($1, $2, $3, $4, $5, $6, $7)", "%s")


### PR DESCRIPTION
### Problem

A client that logs out and logs back in under the same device ID gets a fresh Olm
account. After that round trip `crypto_device` holds a mixed row: the new
`identity_key` next to the *previous* `signing_key`. Every Olm message from that
device is then dropped with

    sender_device_keys: received update for device with different signing key (expected …, got …)

so `m.room_key` never lands and the megolm session cannot be decrypted. Seen in
production on a bridge: the user silently stopped being able to send anything.

### How the row gets mixed

1. Logging out does not delete the row — `PutDevices` only sets `deleted=true`.
2. The client comes back with the same device ID and a new Olm account.
3. `validateDevice` would reject the new keys on a signing key mismatch, but the
   existing-device lookup goes through `GetDevices`, which filters `deleted=false`.
   The soft-deleted row is invisible there, `existing == nil`, nothing to compare
   against, so the new keys pass.
4. `PutDevices` runs `INSERT … ON CONFLICT (user_id, device_id) DO UPDATE`. The SET
   list covers `identity_key`, `deleted`, `trust` and `name` — but not
   `signing_key`, so the old one stays in the row.
5. The Olm path resolves the device with `FindDeviceByKey`, which — unlike
   `GetDevices` — does not filter `deleted`. It finds the mixed row,
   `validateDevice` compares the ed25519 key from the envelope against the stale
   `signing_key`, and the event is discarded.

### The change

`signing_key=excluded.signing_key` added to the ON CONFLICT SET list.

Outside tests `PutDevice` is called from `crypto/machine.go` (own device on start)
and from `verificationhelper` (`sas.go`, `reciprocate.go`); in the latter three the
device comes straight out of `GetOrFetchDevice`, so the signing key only
round-trips through the store and the change is a no-op there. `PutDevices` is
called from `crypto/devicelist.go` for `/keys/query` results, which have already
passed `validateDevice`.

### Test

`crypto/signing_key_repro_test.go` reproduces the round trip on the existing
`getCryptoStores` helper. Without the change it fails with
`expected "signing-2", actual "signing-1"`; with it `./crypto/...` is green
(`-tags goolm`; `crypto/libolm` needs libolm headers and was not built).

### Not fixed here

The asymmetry underneath is left alone: `GetDevices` filters `deleted=false`,
`FindDeviceByKey` does not. The validation path cannot see a soft-deleted row and
lets new keys through, while the Olm path sees that same row and rejects
everything against it. Whether to align the two is your call.
