### PR TITLE
bridgev2: pass Android app metadata through FCM push config

### DIFF
--- a/bridgev2/networkinterface.go
+++ b/bridgev2/networkinterface.go
@@ -1049,7 +1049,8 @@ type WebPushConfig struct {
 }
 
 type FCMPushConfig struct {
-	SenderID string `json:"sender_id"`
+	SenderID string          `json:"sender_id"`
+	Android  json.RawMessage `json:"android,omitempty"`
 }
 
 type APNsPushConfig struct {


### PR DESCRIPTION
Android FCM registration needs app metadata in addition to the sender ID. This lets bridges pass it through the SDK's existing push relay flow.

The field is optional, so sender-only registrations are unchanged.
